### PR TITLE
feat: add summarization task support

### DIFF
--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -4,7 +4,6 @@ package hfgo
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -76,12 +75,7 @@ func TestChatService_Complete_ModelSelection(t *testing.T) {
 			require.NotNil(t, mt.LastRequest)
 			require.Equal(t, EndpointChatCompletion, mt.LastRequest.URL.Path)
 
-			body, err := io.ReadAll(mt.LastRequest.Body)
-			require.NoError(t, err)
-			_ = mt.LastRequest.Body.Close()
-
-			var got map[string]any
-			require.NoError(t, json.Unmarshal(body, &got))
+			got := testutils.ReadRequestBody(t, mt)
 			require.Equal(t, tc.wantModel, got["model"])
 
 			if tc.reqModel == nil {
@@ -187,10 +181,7 @@ func TestChatService_CompleteStream_Success(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 
 	require.NotNil(t, mt.LastRequest)
-	bodyBytes, err := io.ReadAll(mt.LastRequest.Body)
-	require.NoError(t, err)
-	var payload map[string]any
-	require.NoError(t, json.Unmarshal(bodyBytes, &payload))
+	payload := testutils.ReadRequestBody(t, mt)
 	require.Equal(t, true, payload["stream"])
 	require.Equal(t, "default-model", payload["model"])
 }
@@ -721,12 +712,7 @@ func TestChatService_ProviderFallback(t *testing.T) {
 		require.NotNil(t, mt.LastRequest)
 		require.Equal(t, EndpointChatCompletion, mt.LastRequest.URL.Path)
 
-		body, err := io.ReadAll(mt.LastRequest.Body)
-		require.NoError(t, err)
-		_ = mt.LastRequest.Body.Close()
-
-		var got map[string]any
-		require.NoError(t, json.Unmarshal(body, &got))
+		got := testutils.ReadRequestBody(t, mt)
 		require.Equal(t, tc.wantModel, got["model"], tc.description)
 	}
 

--- a/client.go
+++ b/client.go
@@ -59,6 +59,15 @@ func (c Client) FillMask() FillMaskService {
 	return newFillMaskService(c.opts)
 }
 
+// Summarization returns a SummarizationService instance configured with this client's options.
+// The summarization service provides methods for interacting with summarization endpoints.
+// Service configurations are captured at creation time and do not change if the client options change later.
+// Clients are immutable to keep concurrency simple and request behavior predictable.
+// Services are lightweight; prefer to call Summarization() per use instead of retaining the value.
+func (c Client) Summarization() SummarizationService {
+	return newSummarizationService(c.opts)
+}
+
 // Raw returns a RawService instance configured with this client's options.
 // The raw service provides methods for sending raw HTTP requests to any desired endpoint.
 // Service configurations are captured at creation time and do not change if the client options change later.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -390,6 +390,7 @@ Batch text summarization for multiple inputs.
 
 ### RawService
 Created via `client.Raw()`. For raw HTTP requests without type-safe JSON handling.
+
 #### Do(body []byte, method, path string, opts ...Option) (*http.Response, error)
 Raw request with error interpretation on non-2xx responses.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@ The SDK follows a strict immutability pattern for concurrency safety:
    - `ChatService`: Chat completion endpoints (Complete, CompleteStream)
    - `TextClassificationService`: Text classification endpoints (Classify, ClassifyBatch)
    - `ZeroShotTextClassificationService`: Zero-shot text classification endpoints (Classify, ClassifyBatch)
+   - `SummarizationService`: Summarization endpoints (Summarize, SummarizeBatch)
    - `RawService`: Raw HTTP request handling (Do, DoRaw, Stream, StreamReader)
 
 3. **Per-Request Options**: Can override client defaults for single calls
@@ -366,9 +367,29 @@ Batch zero-shot text classification for multiple inputs.
 **API Response Normalization**:
 The HuggingFace API returns batched zero-shot results in a different format than single inputs. The service transparently normalizes responses via `normalizeZeroShotTextClassificationResponse()`.
 
+### SummarizationService
+Created via `client.Summarization()`. For text summarization tasks.
+
+#### Summarize(req SummarizationRequest, opts ...Option) ([]Summarization, error)
+Single text summarization.
+
+**Behavior**:
+- Validates that a model is configured
+- Returns SDK error (kind: Configuration) if the model is missing
+- Applies per-request options
+- Returns a flat list of `Summarization` outputs for the single input
+
+#### SummarizeBatch(req SummarizationBatchRequest, opts ...Option) ([]Summarization, error)
+Batch text summarization for multiple inputs.
+
+**Behavior**:
+- Validates that a model is configured
+- Returns SDK error (kind: Configuration) if the model is missing
+- Applies per-request options
+- The API returns a flat list of `Summarization` outputs (one per input, in order) rather than a nested list, consistent with how it returns a list even for a single input
+
 ### RawService
 Created via `client.Raw()`. For raw HTTP requests without type-safe JSON handling.
-
 #### Do(body []byte, method, path string, opts ...Option) (*http.Response, error)
 Raw request with error interpretation on non-2xx responses.
 

--- a/examples/summarization/basic/summarization.go
+++ b/examples/summarization/basic/summarization.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Kardbord/hfgo/v4"
+)
+
+func main() {
+	token := os.Getenv("HF_TOKEN")
+	if token == "" {
+		log.Fatal("HF_TOKEN environment variable is not set")
+	}
+
+	// Create a new client with your API token and desired model
+	client := hfgo.NewClient(
+		hfgo.WithToken(token),
+		hfgo.WithModel("facebook/bart-large-cnn"),
+	)
+
+	input := "The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building. " +
+		"Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel " +
+		"Tower surpassed the Washington Monument to become the tallest man-made structure in the world."
+
+	fmt.Println("Summarizing input:")
+	PrintJSON(input)
+	fmt.Println("...")
+
+	// Make the summarization request
+	summaries, err := client.Summarization().Summarize(
+		hfgo.SummarizationRequest{
+			Input: input,
+		},
+	)
+	if err != nil {
+		log.Fatalf("error running summarization: %v\n", err)
+	}
+
+	fmt.Println("Results:")
+	PrintJSON(summaries)
+}
+
+func PrintJSON[T any](v T) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		log.Fatalf("error printing JSON: %v\n", err)
+	}
+
+	fmt.Println(string(b))
+}

--- a/examples/summarization/batch/summarization_batch.go
+++ b/examples/summarization/batch/summarization_batch.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Kardbord/hfgo/v4"
+)
+
+func main() {
+	token := os.Getenv("HF_TOKEN")
+	if token == "" {
+		log.Fatal("HF_TOKEN environment variable is not set")
+	}
+
+	// Create a new client with your API token and desired model
+	client := hfgo.NewClient(
+		hfgo.WithToken(token),
+		hfgo.WithModel("facebook/bart-large-cnn"),
+	)
+
+	inputs := []string{
+		"The Earth orbits the Sun once every 365 days, giving us a year.",
+		"The Moon orbits the Earth roughly every 27 days, a period known as a sidereal month.",
+	}
+
+	fmt.Println("Summarizing inputs:")
+	PrintJSON(inputs)
+	fmt.Println("...")
+
+	// Make the batched summarization request
+	summaries, err := client.Summarization().SummarizeBatch(
+		hfgo.SummarizationBatchRequest{
+			Inputs: inputs,
+		},
+	)
+	if err != nil {
+		log.Fatalf("error running batched summarization: %v\n", err)
+	}
+
+	fmt.Println("Results:")
+	PrintJSON(summaries)
+}
+
+func PrintJSON[T any](v T) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		log.Fatalf("error printing JSON: %v\n", err)
+	}
+
+	fmt.Println(string(b))
+}

--- a/examples/summarization/params/summarization_params.go
+++ b/examples/summarization/params/summarization_params.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Kardbord/hfgo/v4"
+)
+
+func main() {
+	token := os.Getenv("HF_TOKEN")
+	if token == "" {
+		log.Fatal("HF_TOKEN environment variable is not set")
+	}
+
+	// Create a new client with your API token and desired model
+	client := hfgo.NewClient(
+		hfgo.WithToken(token),
+		hfgo.WithModel("facebook/bart-large-cnn"),
+	)
+
+	input := "The industrial revolution transformed agriculture, manufacturing, mining, and transport, " +
+		"leading to massive social and economic changes across the world."
+
+	cleanUp := true
+	truncation := hfgo.SummarizationTruncationOnlyFirst
+
+	fmt.Println("Summarizing input:")
+	PrintJSON(input)
+	fmt.Println("...")
+
+	// Make the summarization request with custom parameters
+	summaries, err := client.Summarization().Summarize(
+		hfgo.SummarizationRequest{
+			Input: input,
+			Parameters: &hfgo.SummarizationParameters{
+				CleanUpTokenizationSpaces: &cleanUp,
+				Truncation:                &truncation,
+			},
+		},
+	)
+	if err != nil {
+		log.Fatalf("error running summarization: %v\n", err)
+	}
+
+	fmt.Println("Results:")
+	PrintJSON(summaries)
+}
+
+func PrintJSON[T any](v T) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		log.Fatalf("error printing JSON: %v\n", err)
+	}
+
+	fmt.Println(string(b))
+}

--- a/fill_mask_service.go
+++ b/fill_mask_service.go
@@ -1,8 +1,6 @@
 package hfgo
 
 import (
-	"net/http"
-
 	"github.com/Kardbord/hfgo/v4/internal/request"
 )
 
@@ -26,27 +24,11 @@ func (s FillMaskService) Fill(
 	req FillMaskRequest,
 	opts ...Option,
 ) ([]FillMaskPrediction, error) {
-	optsOverride := s.opts.With(opts...)
-
-	if optsOverride.Model == "" {
-		return nil, &SDKError{
-			Kind:    SDKErrorKindConfiguration,
-			Message: "the model option must be set for the fill mask request to succeed",
-			Err:     nil,
-		}
-	}
-
-	resp, err := request.DoJSON[FillMaskRequest, []FillMaskPrediction](
-		optsOverride,
-		http.MethodPost,
-		"hf-inference/models/"+optsOverride.Model,
+	return doModelInference[FillMaskRequest, []FillMaskPrediction](
+		s.opts.With(opts...),
+		"fill mask",
 		req,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
 }
 
 // FillBatch sends a fill mask request for a batch of inputs
@@ -63,25 +45,9 @@ func (s FillMaskService) FillBatch(
 	req FillMaskBatchRequest,
 	opts ...Option,
 ) ([][]FillMaskPrediction, error) {
-	optsOverride := s.opts.With(opts...)
-
-	if optsOverride.Model == "" {
-		return nil, &SDKError{
-			Kind:    SDKErrorKindConfiguration,
-			Message: "the model option must be set for the fill mask request to succeed",
-			Err:     nil,
-		}
-	}
-
-	resp, err := request.DoJSON[FillMaskBatchRequest, [][]FillMaskPrediction](
-		optsOverride,
-		http.MethodPost,
-		"hf-inference/models/"+optsOverride.Model,
+	return doModelInference[FillMaskBatchRequest, [][]FillMaskPrediction](
+		s.opts.With(opts...),
+		"fill mask",
 		req,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
 }

--- a/fill_mask_service_test.go
+++ b/fill_mask_service_test.go
@@ -3,8 +3,6 @@
 package hfgo
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 	"testing"
 
@@ -130,15 +128,7 @@ func TestFillMaskService_FillMask_WithParameters(t *testing.T) {
 	require.NotNil(t, result)
 
 	// Verify the request was made correctly
-	require.NotNil(t, mt.LastRequest)
-	body, err := io.ReadAll(mt.LastRequest.Body)
-	require.NoError(t, err)
-	_ = mt.LastRequest.Body.Close()
-
-	var reqBody map[string]any
-	err = json.Unmarshal(body, &reqBody)
-	require.NoError(t, err)
-
+	reqBody := testutils.ReadRequestBody(t, mt)
 	params, ok := reqBody["parameters"].(map[string]any)
 	require.True(t, ok, "parameters should be a map")
 	require.InEpsilon(t, float64(5), params["top_k"], 0.001)
@@ -355,14 +345,7 @@ func TestFillMaskService_FillMaskBatch_ModelFromOptions(t *testing.T) {
 	require.Contains(t, mt.LastRequest.URL.Path, "override-model")
 
 	// Verify the batch request body marshals "inputs" as a JSON array
-	body, err := io.ReadAll(mt.LastRequest.Body)
-	require.NoError(t, err)
-	_ = mt.LastRequest.Body.Close()
-
-	var reqBody map[string]any
-	err = json.Unmarshal(body, &reqBody)
-	require.NoError(t, err)
-
+	reqBody := testutils.ReadRequestBody(t, mt)
 	inputs, ok := reqBody["inputs"].([]any)
 	require.True(t, ok, "inputs should be an array for batched requests")
 	require.Len(t, inputs, 1)

--- a/fill_mask_service_test.go
+++ b/fill_mask_service_test.go
@@ -154,68 +154,39 @@ func TestFillMaskService_FillMask_WithParameters(t *testing.T) {
 func TestFillMaskService_FillMask_Errors(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name           string
-		withModel      bool
-		httpStatusCode int
-		responseBody   string
-		want           testutils.WantErr
-		sdkErrKind     hferrors.SDKErrorKind
-		description    string
-	}{
-		{
-			name:           "no model configured",
-			withModel:      false,
-			httpStatusCode: http.StatusOK,
-			responseBody:   `[{"sequence":"test","score":0.95,"token":1,"token_str":"test"}]`,
-			want:           testutils.WantErrSDK,
-			sdkErrKind:     hferrors.SDKErrorKindConfiguration,
-			description:    "SDK error when model is missing",
+	runErrorCases(t,
+		[]errorCase{
+			{
+				name:         "no model configured",
+				statusCode:   http.StatusOK,
+				responseBody: `[{"sequence":"test","score":0.95,"token":1,"token_str":"test"}]`,
+				want:         testutils.WantErrSDK,
+				sdkErrKind:   hferrors.SDKErrorKindConfiguration,
+				description:  "SDK error when model is missing",
+			},
+			{
+				name:         "API error on 404",
+				withModel:    true,
+				statusCode:   http.StatusNotFound,
+				responseBody: `{"error":"Model not found"}`,
+				want:         testutils.WantErrAPI,
+				description:  "API error for nonexistent model",
+			},
+			{
+				name:         "API error on 503",
+				withModel:    true,
+				statusCode:   http.StatusServiceUnavailable,
+				responseBody: `{"error":"Model loading"}`,
+				want:         testutils.WantErrAPI,
+				description:  "API error for model not yet loaded",
+			},
 		},
-		{
-			name:           "API error on 404",
-			withModel:      true,
-			httpStatusCode: http.StatusNotFound,
-			responseBody:   `{"error":"Model not found"}`,
-			want:           testutils.WantErrAPI,
-			description:    "API error for nonexistent model",
-		},
-		{
-			name:           "API error on 503",
-			withModel:      true,
-			httpStatusCode: http.StatusServiceUnavailable,
-			responseBody:   `{"error":"Model loading"}`,
-			want:           testutils.WantErrAPI,
-			description:    "API error for model not yet loaded",
-		},
-	}
-
-	for i := range cases {
-		tc := cases[i]
-		t.Run(tc.name, func(t *testing.T) {
-			mt := testutils.NewJSONMockTransport(tc.httpStatusCode, tc.responseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-			if tc.withModel {
-				opts = opts.WithModel("nonexistent-model")
-			}
-			svc := newFillMaskService(opts)
-
-			req := FillMaskRequest{
+		func(opts request.Options) ([]FillMaskPrediction, error) {
+			return newFillMaskService(opts).Fill(FillMaskRequest{
 				Input: "The capital of France is [MASK].",
-			}
-
-			result, err := svc.Fill(req)
-			require.Error(t, err, tc.description)
-			require.Nil(t, result)
-
-			testutils.AssertErrorType(t, err, tc.want, tc.sdkErrKind, tc.httpStatusCode)
-			if tc.want == testutils.WantErrSDK {
-				// SDK config errors short-circuit before any request
-				require.Nil(t, mt.LastRequest)
-			}
-		})
-	}
+			})
+		},
+	)
 }
 
 func TestFillMaskService_FillMaskBatch_ResponseDecoding(t *testing.T) {
@@ -324,68 +295,39 @@ func TestFillMaskService_FillMaskBatch_ResponseDecoding(t *testing.T) {
 func TestFillMaskService_FillMaskBatch_Errors(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name           string
-		withModel      bool
-		httpStatusCode int
-		responseBody   string
-		want           testutils.WantErr
-		sdkErrKind     hferrors.SDKErrorKind
-		description    string
-	}{
-		{
-			name:           "no model configured",
-			withModel:      false,
-			httpStatusCode: http.StatusOK,
-			responseBody:   `[[]]`,
-			want:           testutils.WantErrSDK,
-			sdkErrKind:     hferrors.SDKErrorKindConfiguration,
-			description:    "SDK error when model is missing",
+	runErrorCases(t,
+		[]errorCase{
+			{
+				name:         "no model configured",
+				statusCode:   http.StatusOK,
+				responseBody: `[[]]`,
+				want:         testutils.WantErrSDK,
+				sdkErrKind:   hferrors.SDKErrorKindConfiguration,
+				description:  "SDK error when model is missing",
+			},
+			{
+				name:         "API error on 404",
+				withModel:    true,
+				statusCode:   http.StatusNotFound,
+				responseBody: `{"error":"Model not found"}`,
+				want:         testutils.WantErrAPI,
+				description:  "API error for nonexistent model",
+			},
+			{
+				name:         "API error on 503",
+				withModel:    true,
+				statusCode:   http.StatusServiceUnavailable,
+				responseBody: `{"error":"Model loading"}`,
+				want:         testutils.WantErrAPI,
+				description:  "API error for model not yet loaded",
+			},
 		},
-		{
-			name:           "API error on 404",
-			withModel:      true,
-			httpStatusCode: http.StatusNotFound,
-			responseBody:   `{"error":"Model not found"}`,
-			want:           testutils.WantErrAPI,
-			description:    "API error for nonexistent model",
-		},
-		{
-			name:           "API error on 503",
-			withModel:      true,
-			httpStatusCode: http.StatusServiceUnavailable,
-			responseBody:   `{"error":"Model loading"}`,
-			want:           testutils.WantErrAPI,
-			description:    "API error for model not yet loaded",
-		},
-	}
-
-	for i := range cases {
-		tc := cases[i]
-		t.Run(tc.name, func(t *testing.T) {
-			mt := testutils.NewJSONMockTransport(tc.httpStatusCode, tc.responseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-			if tc.withModel {
-				opts = opts.WithModel("nonexistent-model")
-			}
-			svc := newFillMaskService(opts)
-
-			req := FillMaskBatchRequest{
+		func(opts request.Options) ([][]FillMaskPrediction, error) {
+			return newFillMaskService(opts).FillBatch(FillMaskBatchRequest{
 				Inputs: []string{"I [MASK] my dog everyday."},
-			}
-
-			result, err := svc.FillBatch(req)
-			require.Error(t, err, tc.description)
-			require.Nil(t, result)
-
-			testutils.AssertErrorType(t, err, tc.want, tc.sdkErrKind, tc.httpStatusCode)
-			if tc.want == testutils.WantErrSDK {
-				// SDK config errors short-circuit before any request
-				require.Nil(t, mt.LastRequest)
-			}
-		})
-	}
+			})
+		},
+	)
 }
 
 func TestFillMaskService_FillMaskBatch_ModelFromOptions(t *testing.T) {

--- a/internal/testutils/body.go
+++ b/internal/testutils/body.go
@@ -1,0 +1,25 @@
+package testutils
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ReadRequestBody reads and closes the last captured request body from mt and
+// unmarshals it as JSON into a map. It fails the test on any error.
+func ReadRequestBody(t *testing.T, mt *MockTransport) map[string]any {
+	t.Helper()
+
+	require.NotNil(t, mt.LastRequest)
+	body, err := io.ReadAll(mt.LastRequest.Body)
+	require.NoError(t, err)
+	require.NoError(t, mt.LastRequest.Body.Close())
+
+	var reqBody map[string]any
+	require.NoError(t, json.Unmarshal(body, &reqBody))
+
+	return reqBody
+}

--- a/internal/testutils/errors.go
+++ b/internal/testutils/errors.go
@@ -18,27 +18,6 @@ const (
 	WantErrAPI
 )
 
-// AssertErrorType asserts err is an SDKError of sdkErrKind (when want is
-// WantErrSDK) or an APIError with the given status (when want is WantErrAPI).
-func AssertErrorType(
-	t *testing.T,
-	err error,
-	want WantErr,
-	sdkErrKind hferrors.SDKErrorKind,
-	apiStatus int,
-) {
-	t.Helper()
-
-	switch want {
-	case WantErrSDK:
-		AssertSDKErrorKind(t, err, sdkErrKind)
-	case WantErrAPI:
-		AssertAPIErrorStatus(t, err, apiStatus)
-	default:
-		t.Fatalf("unknown error expectation: %v", want)
-	}
-}
-
 // AssertSDKErrorKind fails the test if err is not an SDKError of the expected kind.
 func AssertSDKErrorKind(t *testing.T, err error, want hferrors.SDKErrorKind) {
 	t.Helper()

--- a/internal/testutils/errors.go
+++ b/internal/testutils/errors.go
@@ -1,10 +1,10 @@
 package testutils
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
+	"github.com/stretchr/testify/require"
 )
 
 // WantErr selects which SDK error type a test expects from an API call.
@@ -44,12 +44,8 @@ func AssertSDKErrorKind(t *testing.T, err error, want hferrors.SDKErrorKind) {
 	t.Helper()
 
 	var sdkErr *hferrors.SDKError
-	if !errors.As(err, &sdkErr) {
-		t.Fatalf("expected SDKError, got %T", err)
-	}
-	if sdkErr.Kind != want {
-		t.Fatalf("expected SDKError kind %q, got %q", want, sdkErr.Kind)
-	}
+	require.ErrorAs(t, err, &sdkErr)
+	require.Equal(t, want, sdkErr.Kind)
 }
 
 // AssertAPIErrorStatus fails the test if err is not an APIError with the expected status.
@@ -58,12 +54,8 @@ func AssertAPIErrorStatus(t *testing.T, err error, want int) *hferrors.APIError 
 	t.Helper()
 
 	var apiErr *hferrors.APIError
-	if !errors.As(err, &apiErr) {
-		t.Fatalf("expected APIError, got %T", err)
-	}
-	if apiErr.StatusCode != want {
-		t.Fatalf("expected status %d, got %d", want, apiErr.StatusCode)
-	}
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, want, apiErr.StatusCode)
 
 	return apiErr
 }

--- a/internal/testutils/url.go
+++ b/internal/testutils/url.go
@@ -3,6 +3,9 @@ package testutils
 import (
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // AssertURL compares a raw URL string to the expected URL parts.
@@ -10,23 +13,11 @@ func AssertURL(t *testing.T, raw string, want *url.URL) {
 	t.Helper()
 
 	got, err := url.Parse(raw)
-	if err != nil {
-		t.Fatalf("failed to parse URL %q: %v", raw, err)
-	}
+	require.NoError(t, err, "failed to parse URL %q", raw)
 
-	if got.Scheme != want.Scheme {
-		t.Errorf("unexpected scheme: %s", got.Scheme)
-	}
-	if got.Host != want.Host {
-		t.Errorf("unexpected host: %s", got.Host)
-	}
-	if got.Path != want.Path {
-		t.Errorf("unexpected path: %s", got.Path)
-	}
-	if got.RawQuery != want.RawQuery {
-		t.Errorf("unexpected query: %s", got.RawQuery)
-	}
-	if got.Fragment != want.Fragment {
-		t.Errorf("unexpected fragment: %s", got.Fragment)
-	}
+	assert.Equal(t, want.Scheme, got.Scheme)
+	assert.Equal(t, want.Host, got.Host)
+	assert.Equal(t, want.Path, got.Path)
+	assert.Equal(t, want.RawQuery, got.RawQuery)
+	assert.Equal(t, want.Fragment, got.Fragment)
 }

--- a/model_request.go
+++ b/model_request.go
@@ -1,0 +1,30 @@
+package hfgo
+
+import (
+	"net/http"
+
+	"github.com/Kardbord/hfgo/v4/internal/request"
+)
+
+// doModelInference posts req to the inference model endpoint for the model
+// configured in opts, returning the typed response. It returns a configuration
+// SDK error when no model is set. task names the inference task in that error
+// message, e.g. "fill mask" or "summarization".
+func doModelInference[Req, Resp any](opts request.Options, task string, req Req) (Resp, error) {
+	var zero Resp
+
+	if opts.Model == "" {
+		return zero, &SDKError{
+			Kind:    SDKErrorKindConfiguration,
+			Message: "the model option must be set for " + task + " to succeed",
+			Err:     nil,
+		}
+	}
+
+	return request.DoJSON[Req, Resp](
+		opts,
+		http.MethodPost,
+		"hf-inference/models/"+opts.Model,
+		req,
+	)
+}

--- a/model_request.go
+++ b/model_request.go
@@ -10,6 +10,10 @@ import (
 // configured in opts, returning the typed response. It returns a configuration
 // SDK error when no model is set. task names the inference task in that error
 // message, e.g. "fill mask" or "summarization".
+//
+// It is intended for pointer or slice response types: on the configuration
+// error path it returns the typed zero value of Resp, which is nil for slices
+// and pointers and so also signals "no result" to callers.
 func doModelInference[Req, Resp any](opts request.Options, task string, req Req) (Resp, error) {
 	var zero Resp
 

--- a/service_errors_test.go
+++ b/service_errors_test.go
@@ -1,0 +1,76 @@
+package hfgo
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Kardbord/hfgo/v4/internal/hferrors"
+	"github.com/Kardbord/hfgo/v4/internal/request"
+	"github.com/Kardbord/hfgo/v4/internal/testutils"
+)
+
+// errorCase describes a single expected-error scenario for a service call.
+// It is shared by the per-service error-table tests.
+type errorCase struct {
+	// name is the subtest name.
+	name string
+	// withModel reports whether a model option should be set for the call.
+	withModel bool
+	// statusCode is the mocked HTTP status code returned by the transport.
+	statusCode int
+	// responseBody is the mocked response body returned by the transport.
+	responseBody string
+	// want selects whether an SDK or API error is expected.
+	want testutils.WantErr
+	// sdkErrKind is the expected error kind when want is WantErrSDK.
+	sdkErrKind hferrors.SDKErrorKind
+	// description explains the scenario; it is used in failure messages.
+	description string
+}
+
+// runErrorCases runs each errorCase against run, asserting the expected error
+// type. For each case it builds options backed by a mock transport (with a
+// model set only when withModel is true), invokes run, and verifies that:
+//
+//   - an error is returned,
+//   - it is of the expected type (SDKError kind or APIError status), and
+//   - SDK configuration errors make no request.
+//
+// run issues a single service call with the given options and returns its
+// result. Keeping the table loop here avoids duplicating it across services.
+func runErrorCases[Res any](
+	t *testing.T,
+	cases []errorCase,
+	run func(opts request.Options) (Res, error),
+) {
+	t.Helper()
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			mt := testutils.NewJSONMockTransport(tc.statusCode, tc.responseBody, nil)
+			opts := request.NewOptions().WithHTTPClientFactory(func() http.Client {
+				return testutils.NewMockHTTPClient(mt)
+			})
+			if tc.withModel {
+				opts = opts.WithModel("nonexistent-model")
+			}
+
+			result, err := run(opts)
+			if err == nil {
+				t.Fatalf("expected an error: %s", tc.description)
+			}
+
+			if tc.want == testutils.WantErrSDK {
+				testutils.AssertSDKErrorKind(t, err, tc.sdkErrKind)
+				if mt.LastRequest != nil {
+					t.Fatal("SDK config errors short-circuit before any request")
+				}
+			} else {
+				testutils.AssertAPIErrorStatus(t, err, tc.statusCode)
+			}
+
+			_ = result
+		})
+	}
+}

--- a/service_errors_test.go
+++ b/service_errors_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
 	"github.com/Kardbord/hfgo/v4/internal/request"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 // errorCase describes a single expected-error scenario for a service call.
@@ -33,6 +34,7 @@ type errorCase struct {
 // model set only when withModel is true), invokes run, and verifies that:
 //
 //   - an error is returned,
+//   - the result is nil,
 //   - it is of the expected type (SDKError kind or APIError status), and
 //   - SDK configuration errors make no request.
 //
@@ -60,6 +62,7 @@ func runErrorCases[Res any](
 			if err == nil {
 				t.Fatalf("expected an error: %s", tc.description)
 			}
+			require.Nil(t, result, tc.description)
 
 			if tc.want == testutils.WantErrSDK {
 				testutils.AssertSDKErrorKind(t, err, tc.sdkErrKind)
@@ -69,8 +72,6 @@ func runErrorCases[Res any](
 			} else {
 				testutils.AssertAPIErrorStatus(t, err, tc.statusCode)
 			}
-
-			_ = result
 		})
 	}
 }

--- a/summarization.go
+++ b/summarization.go
@@ -1,0 +1,62 @@
+package hfgo
+
+// SummarizationRequest represents a summarization
+// inference request to the API for a single input.
+type SummarizationRequest struct {
+	// The text to summarize.
+	// Required.
+	Input string `json:"inputs"`
+
+	// Additional inference parameters for summarization.
+	Parameters *SummarizationParameters `json:"parameters,omitempty"`
+}
+
+// SummarizationBatchRequest represents a batched summarization
+// inference request to the API for multiple inputs.
+//
+// NOTE: Batched inference is supported by the upstream API, but is not
+// officially documented; behavior may change without notice.
+type SummarizationBatchRequest struct {
+	// The texts to summarize.
+	// Required.
+	Inputs []string `json:"inputs"`
+
+	// Additional inference parameters for summarization.
+	Parameters *SummarizationParameters `json:"parameters,omitempty"`
+}
+
+// SummarizationParameters specify additional inference
+// parameters for summarization tasks.
+type SummarizationParameters struct {
+	// Whether to clean up the potential extra spaces in the text output.
+	CleanUpTokenizationSpaces *bool `json:"clean_up_tokenization_spaces,omitempty"`
+
+	// The truncation strategy to use.
+	Truncation *string `json:"truncation,omitempty"`
+
+	// GenerateParameters provides additional parametrization of the text
+	// generation algorithm (e.g. "max_new_tokens", "temperature", "top_k").
+	//
+	// It is exposed because it is part of the upstream inference schema, but the
+	// set of valid arguments is not documented by Hugging Face and may depend on
+	// the model being used. Invalid or unsupported arguments can be rejected by
+	// the API.
+	GenerateParameters map[string]any `json:"generate_parameters,omitempty"`
+}
+
+const (
+	// SummarizationTruncationDoNotTruncate keeps the input as-is without any truncation.
+	SummarizationTruncationDoNotTruncate = "do_not_truncate"
+	// SummarizationTruncationLongestFirst truncates the longest side first when the input exceeds the model's maximum length.
+	SummarizationTruncationLongestFirst = "longest_first"
+	// SummarizationTruncationOnlyFirst trims the input on the first (left) side when it exceeds the model's maximum length.
+	SummarizationTruncationOnlyFirst = "only_first"
+	// SummarizationTruncationOnlySecond trims the input on the second (right) side when it exceeds the model's maximum length.
+	SummarizationTruncationOnlySecond = "only_second"
+)
+
+// Summarization represents a summarization output.
+type Summarization struct {
+	// The summarized text.
+	SummaryText string `json:"summary_text"`
+}

--- a/summarization_integration_test.go
+++ b/summarization_integration_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package hfgo
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSummarization_LiveAPI tests a basic summarization request against the live HF API.
+// This test requires the HF_TOKEN environment variable to be set.
+func TestSummarization_LiveAPI(t *testing.T) {
+	apiToken := os.Getenv("HF_TOKEN")
+	require.NotEmpty(t, apiToken, "HF_TOKEN must be set")
+
+	const model = "facebook/bart-large-cnn"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client := NewClient(
+		WithToken(apiToken),
+		WithModel(model),
+		WithContext(ctx),
+	)
+
+	const input = "The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building. " +
+		"Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel " +
+		"Tower surpassed the Washington Monument to become the tallest man-made structure in the world."
+
+	resp, err := client.Summarization().Summarize(
+		SummarizationRequest{
+			Input: input,
+		},
+	)
+
+	require.NoError(t, err, "summarization should succeed")
+	require.NotNil(t, resp, "response should not be nil")
+	require.NotEmpty(t, resp, "response should have content")
+	require.NotEmpty(t, resp[0].SummaryText, "summary text should not be empty")
+}
+
+// TestSummarization_BatchLiveAPI tests batch summarization against the live HF API.
+// This test requires the HF_TOKEN environment variable to be set.
+func TestSummarization_BatchLiveAPI(t *testing.T) {
+	apiToken := os.Getenv("HF_TOKEN")
+	require.NotEmpty(t, apiToken, "HF_TOKEN must be set")
+
+	const model = "facebook/bart-large-cnn"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	client := NewClient(
+		WithToken(apiToken),
+		WithModel(model),
+		WithContext(ctx),
+	)
+
+	inputs := []string{
+		"The Earth orbits the Sun once every 365 days, giving us a year.",
+		"The Moon orbits the Earth roughly every 27 days, a period known as a sidereal month.",
+	}
+
+	resp, err := client.Summarization().SummarizeBatch(
+		SummarizationBatchRequest{
+			Inputs: inputs,
+		},
+	)
+
+	require.NoError(t, err, "batch summarization should succeed")
+	require.NotNil(t, resp, "response should not be nil")
+	require.Len(t, resp, 2, "response should have 2 summaries")
+
+	for i, summary := range resp {
+		require.NotEmpty(t, summary.SummaryText, "summary text should not be empty")
+		t.Logf("Input %d: %s", i, summary.SummaryText)
+	}
+}
+
+// TestSummarization_WithParameters tests summarization with various parameters.
+// This test requires the HF_TOKEN environment variable to be set.
+func TestSummarization_WithParameters(t *testing.T) {
+	apiToken := os.Getenv("HF_TOKEN")
+	require.NotEmpty(t, apiToken, "HF_TOKEN must be set")
+
+	const model = "facebook/bart-large-cnn"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	client := NewClient(
+		WithToken(apiToken),
+		WithModel(model),
+		WithContext(ctx),
+	)
+
+	cleanUp := true
+	truncation := SummarizationTruncationOnlyFirst
+	input := "The industrial revolution transformed agriculture, manufacturing, mining, and transport, " +
+		"leading to massive social and economic changes across the world."
+	resp, err := client.Summarization().Summarize(
+		SummarizationRequest{
+			Input: input,
+			Parameters: &SummarizationParameters{
+				CleanUpTokenizationSpaces: &cleanUp,
+				Truncation:                &truncation,
+			},
+		},
+	)
+
+	require.NoError(t, err, "summarization with parameters should succeed")
+	require.NotNil(t, resp, "response should not be nil")
+	require.NotEmpty(t, resp, "response should have content")
+	require.NotEmpty(t, resp[0].SummaryText, "summary text should not be empty")
+}
+
+// TestSummarization_ContextCancellation tests that context cancellation is respected.
+// This test requires the HF_TOKEN environment variable to be set.
+func TestSummarization_ContextCancellation(t *testing.T) {
+	apiToken := os.Getenv("HF_TOKEN")
+	require.NotEmpty(t, apiToken, "HF_TOKEN must be set")
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := NewClient(
+		WithToken(apiToken),
+		WithModel("facebook/bart-large-cnn"),
+		WithContext(ctx),
+	)
+
+	resp, err := client.Summarization().Summarize(
+		SummarizationRequest{
+			Input: "Some text that should be summarized.",
+		},
+	)
+
+	require.Error(t, err, "request with cancelled context should fail")
+	require.Nil(t, resp, "response should be nil for cancelled context")
+}

--- a/summarization_service.go
+++ b/summarization_service.go
@@ -1,0 +1,58 @@
+package hfgo
+
+import (
+	"github.com/Kardbord/hfgo/v4/internal/request"
+)
+
+// SummarizationService implements summarization calls
+// using the configured request options.
+type SummarizationService struct {
+	opts request.Options
+}
+
+// newSummarizationService builds a SummarizationService with a snapshot
+// of the provided options.
+func newSummarizationService(opts request.Options) SummarizationService {
+	return SummarizationService{opts: opts}
+}
+
+// Summarize sends a summarization request and returns the
+// summarization output for a single input.
+//
+// The API always returns a list for summarization; a single input yields a
+// one-element list rather than a bare summary object.
+//
+// For multiple inputs, use SummarizeBatch.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (s SummarizationService) Summarize(
+	req SummarizationRequest,
+	opts ...Option,
+) ([]Summarization, error) {
+	return doModelInference[SummarizationRequest, []Summarization](
+		s.opts.With(opts...),
+		"summarization",
+		req,
+	)
+}
+
+// SummarizeBatch sends a summarization request for a batch of inputs
+// and returns a flat list of summarization outputs, one for each input in
+// the batch, in the same order as the inputs.
+//
+// NOTE: Batched inference is supported by the upstream API, but is not
+// officially documented; behavior may change without notice. The response is
+// a flat list (one summary per input) — not a nested list — consistent with
+// how the API returns a list even for a single input.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (s SummarizationService) SummarizeBatch(
+	req SummarizationBatchRequest,
+	opts ...Option,
+) ([]Summarization, error) {
+	return doModelInference[SummarizationBatchRequest, []Summarization](
+		s.opts.With(opts...),
+		"summarization",
+		req,
+	)
+}

--- a/summarization_service_test.go
+++ b/summarization_service_test.go
@@ -1,0 +1,328 @@
+//go:build !integration
+
+package hfgo
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/Kardbord/hfgo/v4/internal/hferrors"
+	"github.com/Kardbord/hfgo/v4/internal/request"
+	"github.com/Kardbord/hfgo/v4/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// readRequestBody reads the last captured request body from the mock transport,
+// parses it as JSON, and returns the result. It fails the test on any error.
+func readRequestBody(t *testing.T, mt *testutils.MockTransport) map[string]any {
+	t.Helper()
+
+	require.NotNil(t, mt.LastRequest)
+	body, err := io.ReadAll(mt.LastRequest.Body)
+	require.NoError(t, err)
+	_ = mt.LastRequest.Body.Close()
+
+	var reqBody map[string]any
+	require.NoError(t, json.Unmarshal(body, &reqBody))
+
+	return reqBody
+}
+
+func TestSummarizationService_Summarize_ResponseVariations(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		responseBody string
+		wantLen      int
+		wantSummary  string
+		description  string
+	}{
+		{
+			name:         "single summary",
+			responseBody: `[{"summary_text":"A concise summary."}]`,
+			wantLen:      1,
+			wantSummary:  "A concise summary.",
+			description:  "a single summary is returned",
+		},
+		{
+			name:         "empty response",
+			responseBody: `[]`,
+			wantLen:      0,
+			description:  "empty response passes through as an empty list",
+		},
+		{
+			name:         "multiple summaries",
+			responseBody: `[{"summary_text":"One."},{"summary_text":"Two."}]`,
+			wantLen:      2,
+			wantSummary:  "One.",
+			description:  "multiple summaries in one response pass through",
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
+			opts := request.NewOptions().
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
+				WithModel("test-model")
+			svc := newSummarizationService(opts)
+
+			result, err := svc.Summarize(SummarizationRequest{Input: "Some long text."})
+			require.NoError(t, err, tc.description)
+			require.NotNil(t, result, tc.description)
+			require.Len(t, result, tc.wantLen, tc.description)
+
+			if tc.wantLen > 0 {
+				require.Equal(t, tc.wantSummary, result[0].SummaryText, tc.description)
+			}
+		})
+	}
+}
+
+func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		cleanUp     *bool
+		truncation  *string
+		generate    map[string]any
+		want        map[string]any
+		description string
+	}{
+		{
+			name:        "parameters omitted",
+			description: "nil parameters are omitted from the request body",
+		},
+		{
+			name:        "clean up tokenization spaces",
+			cleanUp:     testutils.Ptr(true),
+			want:        map[string]any{"clean_up_tokenization_spaces": true},
+			description: "clean_up_tokenization_spaces maps to its JSON key",
+		},
+		{
+			name:        "truncation do_not_truncate",
+			truncation:  testutils.Ptr(SummarizationTruncationDoNotTruncate),
+			want:        map[string]any{"truncation": SummarizationTruncationDoNotTruncate},
+			description: "do_not_truncate constant serializes correctly",
+		},
+		{
+			name:        "truncation longest_first",
+			truncation:  testutils.Ptr(SummarizationTruncationLongestFirst),
+			want:        map[string]any{"truncation": SummarizationTruncationLongestFirst},
+			description: "longest_first constant serializes correctly",
+		},
+		{
+			name:        "truncation only_first",
+			truncation:  testutils.Ptr(SummarizationTruncationOnlyFirst),
+			want:        map[string]any{"truncation": SummarizationTruncationOnlyFirst},
+			description: "only_first constant serializes correctly",
+		},
+		{
+			name:        "truncation only_second",
+			truncation:  testutils.Ptr(SummarizationTruncationOnlySecond),
+			want:        map[string]any{"truncation": SummarizationTruncationOnlySecond},
+			description: "only_second constant serializes correctly",
+		},
+		{
+			name:     "generate parameters",
+			generate: map[string]any{"max_new_tokens": 60, "temperature": 0.8},
+			want: map[string]any{
+				"generate_parameters": map[string]any{
+					"max_new_tokens": float64(60),
+					"temperature":    0.8,
+				},
+			},
+			description: "generate_parameters maps to its JSON key",
+		},
+		{
+			name:       "all parameters",
+			cleanUp:    testutils.Ptr(true),
+			truncation: testutils.Ptr(SummarizationTruncationOnlyFirst),
+			generate:   map[string]any{"max_new_tokens": 60},
+			want: map[string]any{
+				"clean_up_tokenization_spaces": true,
+				"truncation":                   SummarizationTruncationOnlyFirst,
+				"generate_parameters":          map[string]any{"max_new_tokens": float64(60)},
+			},
+			description: "all parameters serialize together",
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			mt := testutils.NewJSONMockTransport(
+				http.StatusOK,
+				`[{"summary_text":"A concise summary."}]`,
+				nil,
+			)
+			opts := request.NewOptions().
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
+				WithModel("test-model")
+			svc := newSummarizationService(opts)
+
+			req := SummarizationRequest{Input: "Some long text."}
+			if tc.cleanUp != nil || tc.truncation != nil || tc.generate != nil {
+				req.Parameters = &SummarizationParameters{
+					CleanUpTokenizationSpaces: tc.cleanUp,
+					Truncation:                tc.truncation,
+					GenerateParameters:        tc.generate,
+				}
+			}
+
+			result, err := svc.Summarize(req)
+			require.NoError(t, err, tc.description)
+			require.NotNil(t, result, tc.description)
+
+			reqBody := readRequestBody(t, mt)
+			if tc.want == nil {
+				_, ok := reqBody["parameters"]
+				require.False(t, ok, tc.description)
+
+				return
+			}
+
+			require.Equal(t, tc.want, reqBody["parameters"], tc.description)
+		})
+	}
+}
+
+func TestSummarizationService_Summarize_Errors(t *testing.T) {
+	t.Parallel()
+
+	runErrorCases(t,
+		[]errorCase{
+			{
+				name:         "no model configured",
+				statusCode:   http.StatusOK,
+				responseBody: `[{"summary_text":"A concise summary."}]`,
+				want:         testutils.WantErrSDK,
+				sdkErrKind:   hferrors.SDKErrorKindConfiguration,
+				description:  "SDK error when model is missing",
+			},
+			{
+				name:         "API error on 404",
+				withModel:    true,
+				statusCode:   http.StatusNotFound,
+				responseBody: `{"error":"Model not found"}`,
+				want:         testutils.WantErrAPI,
+				description:  "API error for nonexistent model",
+			},
+		},
+		func(opts request.Options) ([]Summarization, error) {
+			return newSummarizationService(opts).Summarize(SummarizationRequest{
+				Input: "Some long text that should be summarized.",
+			})
+		},
+	)
+}
+
+func TestSummarizationService_SummarizeBatch_ResponseVariations(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		responseBody string
+		want         []string
+		description  string
+	}{
+		{
+			name:         "single input",
+			responseBody: `[{"summary_text":"Summary one."}]`,
+			want:         []string{"Summary one."},
+			description:  "a single batched input returns one summary",
+		},
+		{
+			name:         "multiple inputs",
+			responseBody: `[{"summary_text":"Summary one."},{"summary_text":"Summary two."}]`,
+			want:         []string{"Summary one.", "Summary two."},
+			description:  "each batched input returns its own flat summary",
+		},
+		{
+			name:         "empty response",
+			responseBody: `[]`,
+			want:         []string{},
+			description:  "empty response passes through as an empty list",
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
+			opts := request.NewOptions().
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
+				WithModel("test-model")
+			svc := newSummarizationService(opts)
+
+			result, err := svc.SummarizeBatch(SummarizationBatchRequest{
+				Inputs: []string{"Long text one.", "Long text two."},
+			})
+			require.NoError(t, err, tc.description)
+			require.NotNil(t, result, tc.description)
+			require.Len(t, result, len(tc.want), tc.description)
+
+			for j, summary := range result {
+				require.Equal(t, tc.want[j], summary.SummaryText, tc.description)
+			}
+		})
+	}
+}
+
+func TestSummarizationService_SummarizeBatch_Errors(t *testing.T) {
+	t.Parallel()
+
+	runErrorCases(t,
+		[]errorCase{
+			{
+				name:         "no model configured",
+				statusCode:   http.StatusOK,
+				responseBody: `[{"summary_text":"Summary one."}]`,
+				want:         testutils.WantErrSDK,
+				sdkErrKind:   hferrors.SDKErrorKindConfiguration,
+				description:  "SDK error when model is missing",
+			},
+			{
+				name:         "API error on 404",
+				withModel:    true,
+				statusCode:   http.StatusNotFound,
+				responseBody: `{"error":"Model not found"}`,
+				want:         testutils.WantErrAPI,
+				description:  "API error for nonexistent model",
+			},
+		},
+		func(opts request.Options) ([]Summarization, error) {
+			return newSummarizationService(opts).SummarizeBatch(SummarizationBatchRequest{
+				Inputs: []string{"Long text one."},
+			})
+		},
+	)
+}
+
+func TestSummarizationService_SummarizeBatch_ModelFromOptions(t *testing.T) {
+	t.Parallel()
+
+	mt := testutils.NewJSONMockTransport(
+		http.StatusOK,
+		`[{"summary_text":"Summary one."}]`,
+		nil,
+	)
+	opts := request.NewOptions().
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
+	svc := newSummarizationService(opts)
+
+	result, err := svc.SummarizeBatch(SummarizationBatchRequest{
+		Inputs: []string{"Long text one."},
+	}, WithModel("override-model"))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify the correct model was used in the request
+	require.NotNil(t, mt.LastRequest)
+	require.Contains(t, mt.LastRequest.URL.Path, "override-model")
+}

--- a/summarization_service_test.go
+++ b/summarization_service_test.go
@@ -3,8 +3,6 @@
 package hfgo
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 	"testing"
 
@@ -13,22 +11,6 @@ import (
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
-
-// readRequestBody reads the last captured request body from the mock transport,
-// parses it as JSON, and returns the result. It fails the test on any error.
-func readRequestBody(t *testing.T, mt *testutils.MockTransport) map[string]any {
-	t.Helper()
-
-	require.NotNil(t, mt.LastRequest)
-	body, err := io.ReadAll(mt.LastRequest.Body)
-	require.NoError(t, err)
-	_ = mt.LastRequest.Body.Close()
-
-	var reqBody map[string]any
-	require.NoError(t, json.Unmarshal(body, &reqBody))
-
-	return reqBody
-}
 
 func TestSummarizationService_Summarize_ResponseVariations(t *testing.T) {
 	t.Parallel()
@@ -179,7 +161,7 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result, tc.description)
 
-			reqBody := readRequestBody(t, mt)
+			reqBody := testutils.ReadRequestBody(t, mt)
 			if tc.want == nil {
 				_, ok := reqBody["parameters"]
 				require.False(t, ok, tc.description)

--- a/text_classification_service.go
+++ b/text_classification_service.go
@@ -1,8 +1,6 @@
 package hfgo
 
 import (
-	"net/http"
-
 	"github.com/Kardbord/hfgo/v4/internal/request"
 )
 
@@ -30,23 +28,13 @@ func (s TextClassificationService) Classify(
 ) ([]TextClassification, error) {
 	optsOverride := s.opts.With(opts...)
 
-	if optsOverride.Model == "" {
-		return nil, &SDKError{
-			Kind: SDKErrorKindConfiguration,
-			//nolint:goconst // repeated string is incidental
-			Message: "the model option must be set for text classification to succeed",
-			Err:     nil,
-		}
-	}
-
 	// NOTE: The API documentation indicates that this should return an JSON array of
 	// TextClassification objects, but in reality it returns an array of arrays, where
 	// the outer array contains only a single entry (the inner array), and the inner array
 	// contains a list of TextClassification objects.
-	resp, err := request.DoJSON[TextClassificationRequest, [][]TextClassification](
+	resp, err := doModelInference[TextClassificationRequest, [][]TextClassification](
 		optsOverride,
-		http.MethodPost,
-		"hf-inference/models/"+optsOverride.Model,
+		"text classification",
 		req,
 	)
 	if err != nil {
@@ -77,18 +65,9 @@ func (s TextClassificationService) ClassifyBatch(
 ) ([][]TextClassification, error) {
 	optsOverride := s.opts.With(opts...)
 
-	if optsOverride.Model == "" {
-		return nil, &SDKError{
-			Kind:    SDKErrorKindConfiguration,
-			Message: "the model option must be set for text classification to succeed",
-			Err:     nil,
-		}
-	}
-
-	resp, err := request.DoJSON[TextClassificationBatchRequest, [][]TextClassification](
+	resp, err := doModelInference[TextClassificationBatchRequest, [][]TextClassification](
 		optsOverride,
-		http.MethodPost,
-		"hf-inference/models/"+optsOverride.Model,
+		"text classification",
 		req,
 	)
 	if err != nil {

--- a/text_classification_service_test.go
+++ b/text_classification_service_test.go
@@ -3,8 +3,6 @@
 package hfgo
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 	"testing"
 
@@ -65,15 +63,7 @@ func TestTextClassificationService_Classify_WithParameters(t *testing.T) {
 	require.NotNil(t, result)
 
 	// Verify the request was made correctly
-	require.NotNil(t, mt.LastRequest)
-	body, err := io.ReadAll(mt.LastRequest.Body)
-	require.NoError(t, err)
-	_ = mt.LastRequest.Body.Close()
-
-	var reqBody map[string]any
-	err = json.Unmarshal(body, &reqBody)
-	require.NoError(t, err)
-
+	reqBody := testutils.ReadRequestBody(t, mt)
 	params, ok := reqBody["parameters"].(map[string]any)
 	require.True(t, ok, "parameters should be a map")
 	require.InEpsilon(t, float64(2), params["top_k"], 0.001)

--- a/text_classification_service_test.go
+++ b/text_classification_service_test.go
@@ -82,60 +82,31 @@ func TestTextClassificationService_Classify_WithParameters(t *testing.T) {
 func TestTextClassificationService_Classify_Errors(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name           string
-		withModel      bool
-		httpStatusCode int
-		responseBody   string
-		want           testutils.WantErr
-		sdkErrKind     hferrors.SDKErrorKind
-		description    string
-	}{
-		{
-			name:           "no model configured",
-			withModel:      false,
-			httpStatusCode: http.StatusOK,
-			responseBody:   `[[{"label":"positive","score":0.95}]]`,
-			want:           testutils.WantErrSDK,
-			sdkErrKind:     hferrors.SDKErrorKindConfiguration,
-			description:    "SDK error when model is missing",
+	runErrorCases(t,
+		[]errorCase{
+			{
+				name:         "no model configured",
+				statusCode:   http.StatusOK,
+				responseBody: `[[{"label":"positive","score":0.95}]]`,
+				want:         testutils.WantErrSDK,
+				sdkErrKind:   hferrors.SDKErrorKindConfiguration,
+				description:  "SDK error when model is missing",
+			},
+			{
+				name:         "API error on 404",
+				withModel:    true,
+				statusCode:   http.StatusNotFound,
+				responseBody: `{"error":"Model not found"}`,
+				want:         testutils.WantErrAPI,
+				description:  "API error for nonexistent model",
+			},
 		},
-		{
-			name:           "API error on 404",
-			withModel:      true,
-			httpStatusCode: http.StatusNotFound,
-			responseBody:   `{"error":"Model not found"}`,
-			want:           testutils.WantErrAPI,
-			description:    "API error for nonexistent model",
-		},
-	}
-
-	for i := range cases {
-		tc := cases[i]
-		t.Run(tc.name, func(t *testing.T) {
-			mt := testutils.NewJSONMockTransport(tc.httpStatusCode, tc.responseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-			if tc.withModel {
-				opts = opts.WithModel("nonexistent-model")
-			}
-			svc := newTextClassificationService(opts)
-
-			req := TextClassificationRequest{
+		func(opts request.Options) ([]TextClassification, error) {
+			return newTextClassificationService(opts).Classify(TextClassificationRequest{
 				Input: "test text",
-			}
-
-			result, err := svc.Classify(req)
-			require.Error(t, err, tc.description)
-			require.Nil(t, result)
-
-			testutils.AssertErrorType(t, err, tc.want, tc.sdkErrKind, tc.httpStatusCode)
-			if tc.want == testutils.WantErrSDK {
-				// SDK config errors short-circuit before any request
-				require.Nil(t, mt.LastRequest)
-			}
-		})
-	}
+			})
+		},
+	)
 }
 
 func TestTextClassificationService_ClassifyBatch_ResponseVariations(t *testing.T) {

--- a/tools/bruno/hfgo/summarization/summarization-params.bru
+++ b/tools/bruno/hfgo/summarization/summarization-params.bru
@@ -15,11 +15,7 @@ body:json {
     "inputs": "The industrial revolution transformed agriculture, manufacturing, mining, and transport, leading to massive social and economic changes.",
     "parameters": {
       "clean_up_tokenization_spaces": true,
-      "truncation": "only_first",
-      "generate_parameters": {
-        "max_new_tokens": 60,
-        "temperature": 0.8
-      }
+      "truncation": "only_first"
     }
   }
 }

--- a/zero_shot_text_classification_service.go
+++ b/zero_shot_text_classification_service.go
@@ -2,7 +2,6 @@ package hfgo
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/Kardbord/hfgo/v4/internal/request"
 )
@@ -32,15 +31,6 @@ func (s ZeroShotTextClassificationService) Classify(
 ) ([]ZeroShotTextClassification, error) {
 	optsOverride := s.opts.With(opts...)
 
-	if optsOverride.Model == "" {
-		return nil, &SDKError{
-			Kind: SDKErrorKindConfiguration,
-			//nolint:goconst // repeated string is incidental
-			Message: "the model option must be set for text classification to succeed",
-			Err:     nil,
-		}
-	}
-
 	if req.Parameters == nil || len(req.Parameters.CandidateLabels) == 0 {
 		return nil, &SDKError{
 			Kind:    SDKErrorKindConfiguration,
@@ -49,10 +39,9 @@ func (s ZeroShotTextClassificationService) Classify(
 		}
 	}
 
-	resp, err := request.DoJSON[ZeroShotTextClassificationRequest, []ZeroShotTextClassification](
+	resp, err := doModelInference[ZeroShotTextClassificationRequest, []ZeroShotTextClassification](
 		optsOverride,
-		http.MethodPost,
-		"hf-inference/models/"+optsOverride.Model,
+		"zero-shot text classification",
 		req,
 	)
 	if err != nil {
@@ -78,14 +67,6 @@ func (s ZeroShotTextClassificationService) ClassifyBatch(
 ) ([][]ZeroShotTextClassification, error) {
 	optsOverride := s.opts.With(opts...)
 
-	if optsOverride.Model == "" {
-		return nil, &SDKError{
-			Kind:    SDKErrorKindConfiguration,
-			Message: "the model option must be set for text classification to succeed",
-			Err:     nil,
-		}
-	}
-
 	if req.Parameters == nil || len(req.Parameters.CandidateLabels) == 0 {
 		return nil, &SDKError{
 			Kind:    SDKErrorKindConfiguration,
@@ -94,10 +75,9 @@ func (s ZeroShotTextClassificationService) ClassifyBatch(
 		}
 	}
 
-	resp, err := request.DoJSON[ZeroShotTextClassificationBatchRequest, []zeroShotTextClassificationBatched](
+	resp, err := doModelInference[ZeroShotTextClassificationBatchRequest, []zeroShotTextClassificationBatched](
 		optsOverride,
-		http.MethodPost,
-		"hf-inference/models/"+optsOverride.Model,
+		"zero-shot text classification",
 		req,
 	)
 	if err != nil {

--- a/zero_shot_text_classification_service_test.go
+++ b/zero_shot_text_classification_service_test.go
@@ -42,20 +42,15 @@ func TestZeroShotTextClassificationService_Classify_SingleInput(t *testing.T) {
 	require.InEpsilon(t, 0.95, result[0].Score, 0.001)
 }
 
-func TestZeroShotTextClassificationService_Classify_Errors(t *testing.T) {
+func TestZeroShotTextClassificationService_Classify_CandidateLabelValidation(t *testing.T) {
 	t.Parallel()
 
 	const zeroShotSingleClassificationResponseBody = `[{"label":"positive","score":0.95}]`
 
 	cases := []struct {
-		name           string
-		req            ZeroShotTextClassificationRequest
-		withModel      bool
-		httpStatusCode int
-		responseBody   string
-		want           testutils.WantErr
-		sdkErrKind     hferrors.SDKErrorKind
-		description    string
+		name        string
+		req         ZeroShotTextClassificationRequest
+		description string
 	}{
 		{
 			name: "no candidate labels",
@@ -65,78 +60,75 @@ func TestZeroShotTextClassificationService_Classify_Errors(t *testing.T) {
 					CandidateLabels: []string{},
 				},
 			},
-			withModel:      true,
-			httpStatusCode: http.StatusOK,
-			responseBody:   zeroShotSingleClassificationResponseBody,
-			want:           testutils.WantErrSDK,
-			sdkErrKind:     hferrors.SDKErrorKindConfiguration,
-			description:    "SDK error when candidate labels are empty",
+			description: "SDK error when candidate labels are empty",
 		},
 		{
 			name: "no parameters",
 			req: ZeroShotTextClassificationRequest{
 				Input: "test text",
 			},
-			withModel:      true,
-			httpStatusCode: http.StatusOK,
-			responseBody:   zeroShotSingleClassificationResponseBody,
-			want:           testutils.WantErrSDK,
-			sdkErrKind:     hferrors.SDKErrorKindConfiguration,
-			description:    "SDK error when parameters are missing",
-		},
-		{
-			name: "no model configured",
-			req: ZeroShotTextClassificationRequest{
-				Input: "test text",
-				Parameters: &ZeroShotTextClassificationParameters{
-					CandidateLabels: []string{"positive", "negative"},
-				},
-			},
-			withModel:      false,
-			httpStatusCode: http.StatusOK,
-			responseBody:   zeroShotSingleClassificationResponseBody,
-			want:           testutils.WantErrSDK,
-			sdkErrKind:     hferrors.SDKErrorKindConfiguration,
-			description:    "SDK error when model is missing",
-		},
-		{
-			name: "API error on 404",
-			req: ZeroShotTextClassificationRequest{
-				Input: "test text",
-				Parameters: &ZeroShotTextClassificationParameters{
-					CandidateLabels: []string{"positive", "negative"},
-				},
-			},
-			withModel:      true,
-			httpStatusCode: http.StatusNotFound,
-			responseBody:   `{"error":"Model not found"}`,
-			want:           testutils.WantErrAPI,
-			description:    "API error for nonexistent model",
+			description: "SDK error when parameters are missing",
 		},
 	}
 
 	for i := range cases {
 		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
-			mt := testutils.NewJSONMockTransport(tc.httpStatusCode, tc.responseBody, nil)
+			mt := testutils.NewJSONMockTransport(
+				http.StatusOK,
+				zeroShotSingleClassificationResponseBody,
+				nil,
+			)
 			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-			if tc.withModel {
-				opts = opts.WithModel("nonexistent-model")
-			}
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
+				WithModel("nonexistent-model")
 			svc := newZeroShotTextClassificationService(opts)
 
 			result, err := svc.Classify(tc.req)
-			require.Error(t, err, tc.description)
-			require.Nil(t, result)
-
-			testutils.AssertErrorType(t, err, tc.want, tc.sdkErrKind, tc.httpStatusCode)
-			if tc.want == testutils.WantErrSDK {
-				// SDK config errors short-circuit before any request
-				require.Nil(t, mt.LastRequest)
-			}
+			testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
+			require.Nil(t, result, tc.description)
+			require.Nil(
+				t,
+				mt.LastRequest,
+				"candidate label validation short-circuits before any request",
+			)
 		})
 	}
+}
+
+func TestZeroShotTextClassificationService_Classify_Errors(t *testing.T) {
+	t.Parallel()
+
+	runErrorCases(t,
+		[]errorCase{
+			{
+				name:         "no model configured",
+				statusCode:   http.StatusOK,
+				responseBody: `[{"label":"positive","score":0.95}]`,
+				want:         testutils.WantErrSDK,
+				sdkErrKind:   hferrors.SDKErrorKindConfiguration,
+				description:  "SDK error when model is missing",
+			},
+			{
+				name:         "API error on 404",
+				withModel:    true,
+				statusCode:   http.StatusNotFound,
+				responseBody: `{"error":"Model not found"}`,
+				want:         testutils.WantErrAPI,
+				description:  "API error for nonexistent model",
+			},
+		},
+		func(opts request.Options) ([]ZeroShotTextClassification, error) {
+			return newZeroShotTextClassificationService(
+				opts,
+			).Classify(ZeroShotTextClassificationRequest{
+				Input: "test text",
+				Parameters: &ZeroShotTextClassificationParameters{
+					CandidateLabels: []string{"positive", "negative"},
+				},
+			})
+		},
+	)
 }
 
 func TestZeroShotTextClassificationService_ClassifyBatch_InputVariations(t *testing.T) {
@@ -220,20 +212,15 @@ func TestZeroShotTextClassificationService_ClassifyBatch_InputVariations(t *test
 	}
 }
 
-func TestZeroShotTextClassificationService_ClassifyBatch_Errors(t *testing.T) {
+func TestZeroShotTextClassificationService_ClassifyBatch_CandidateLabelValidation(t *testing.T) {
 	t.Parallel()
 
 	const zeroShotBatchClassificationResponseBody = `[{"Sequence":"text1","Labels":["positive","negative","neutral"],"Scores":[0.95,0.03,0.02]}]`
 
 	cases := []struct {
-		name           string
-		req            ZeroShotTextClassificationBatchRequest
-		withModel      bool
-		httpStatusCode int
-		responseBody   string
-		want           testutils.WantErr
-		sdkErrKind     hferrors.SDKErrorKind
-		description    string
+		name        string
+		req         ZeroShotTextClassificationBatchRequest
+		description string
 	}{
 		{
 			name: "no candidate labels",
@@ -243,78 +230,75 @@ func TestZeroShotTextClassificationService_ClassifyBatch_Errors(t *testing.T) {
 					CandidateLabels: []string{},
 				},
 			},
-			withModel:      true,
-			httpStatusCode: http.StatusOK,
-			responseBody:   zeroShotBatchClassificationResponseBody,
-			want:           testutils.WantErrSDK,
-			sdkErrKind:     hferrors.SDKErrorKindConfiguration,
-			description:    "SDK error when candidate labels are empty",
+			description: "SDK error when candidate labels are empty",
 		},
 		{
 			name: "no parameters",
 			req: ZeroShotTextClassificationBatchRequest{
 				Inputs: []string{"test text"},
 			},
-			withModel:      true,
-			httpStatusCode: http.StatusOK,
-			responseBody:   zeroShotBatchClassificationResponseBody,
-			want:           testutils.WantErrSDK,
-			sdkErrKind:     hferrors.SDKErrorKindConfiguration,
-			description:    "SDK error when parameters are missing",
-		},
-		{
-			name: "no model configured",
-			req: ZeroShotTextClassificationBatchRequest{
-				Inputs: []string{"test text"},
-				Parameters: &ZeroShotTextClassificationParameters{
-					CandidateLabels: []string{"positive", "negative"},
-				},
-			},
-			withModel:      false,
-			httpStatusCode: http.StatusOK,
-			responseBody:   zeroShotBatchClassificationResponseBody,
-			want:           testutils.WantErrSDK,
-			sdkErrKind:     hferrors.SDKErrorKindConfiguration,
-			description:    "SDK error when model is missing",
-		},
-		{
-			name: "API error on 404",
-			req: ZeroShotTextClassificationBatchRequest{
-				Inputs: []string{"test text"},
-				Parameters: &ZeroShotTextClassificationParameters{
-					CandidateLabels: []string{"positive", "negative"},
-				},
-			},
-			withModel:      true,
-			httpStatusCode: http.StatusNotFound,
-			responseBody:   `{"error":"Model not found"}`,
-			want:           testutils.WantErrAPI,
-			description:    "API error for nonexistent model",
+			description: "SDK error when parameters are missing",
 		},
 	}
 
 	for i := range cases {
 		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
-			mt := testutils.NewJSONMockTransport(tc.httpStatusCode, tc.responseBody, nil)
+			mt := testutils.NewJSONMockTransport(
+				http.StatusOK,
+				zeroShotBatchClassificationResponseBody,
+				nil,
+			)
 			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-			if tc.withModel {
-				opts = opts.WithModel("nonexistent-model")
-			}
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
+				WithModel("nonexistent-model")
 			svc := newZeroShotTextClassificationService(opts)
 
 			result, err := svc.ClassifyBatch(tc.req)
-			require.Error(t, err, tc.description)
-			require.Nil(t, result)
-
-			testutils.AssertErrorType(t, err, tc.want, tc.sdkErrKind, tc.httpStatusCode)
-			if tc.want == testutils.WantErrSDK {
-				// SDK config errors short-circuit before any request
-				require.Nil(t, mt.LastRequest)
-			}
+			testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
+			require.Nil(t, result, tc.description)
+			require.Nil(
+				t,
+				mt.LastRequest,
+				"candidate label validation short-circuits before any request",
+			)
 		})
 	}
+}
+
+func TestZeroShotTextClassificationService_ClassifyBatch_Errors(t *testing.T) {
+	t.Parallel()
+
+	runErrorCases(t,
+		[]errorCase{
+			{
+				name:         "no model configured",
+				statusCode:   http.StatusOK,
+				responseBody: `[{"Sequence":"text1","Labels":["positive","negative","neutral"],"Scores":[0.95,0.03,0.02]}]`,
+				want:         testutils.WantErrSDK,
+				sdkErrKind:   hferrors.SDKErrorKindConfiguration,
+				description:  "SDK error when model is missing",
+			},
+			{
+				name:         "API error on 404",
+				withModel:    true,
+				statusCode:   http.StatusNotFound,
+				responseBody: `{"error":"Model not found"}`,
+				want:         testutils.WantErrAPI,
+				description:  "API error for nonexistent model",
+			},
+		},
+		func(opts request.Options) ([][]ZeroShotTextClassification, error) {
+			return newZeroShotTextClassificationService(
+				opts,
+			).ClassifyBatch(ZeroShotTextClassificationBatchRequest{
+				Inputs: []string{"test text"},
+				Parameters: &ZeroShotTextClassificationParameters{
+					CandidateLabels: []string{"positive", "negative"},
+				},
+			})
+		},
+	)
 }
 
 func TestZeroShotTextClassificationService_ClassifyBatch_ModelFromOptions(t *testing.T) {


### PR DESCRIPTION
Implement the summarization inference task, mirroring the existing model-POST service pattern:

- Add SummarizationService with Summarize and SummarizeBatch, exposed via client.Summarization() (noun accessor to avoid the Summarize() .Summarize() stutter).
- Add SummarizationRequest/SummarizationBatchRequest DTOs and the Summarization output type. GenerateParameters is exposed because it is part of the upstream schema; valid arguments are undocumented and model-dependent.
- Document the API quirk that summarization always returns a flat list: a single input yields a one-element list, and batched input yields a one-summary-per-input flat list rather than a nested list.
- Extract doModelInference, a shared generic helper for the model-POST guard and request dispatch, and use it across fill-mask, summarization, text classification, and zero-shot classification.
- Centralize per-service error-table tests into a shared runErrorCases helper.
- Add unit and integration tests, plus basic/batch/params examples. Update docs/architecture.md.