### PR TITLE
refactor!: flatten inference services into Client methods; by-value chat requests; add deep-clone methods to request DTOs; update concurrency guarantees

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,8 @@ linters:
           - lll
         source: "^//go:generate "
   settings:
+    exhaustruct:
+      allow-empty-returns: true
     ireturn:
       allow:
         - error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ See `docs/architecture.md` for comprehensive technical documentation including:
 - Concurrency safety model
 - Detailed error handling
 - Complete API reference
-- Service implementations
+- Client method API
 - CI/CD workflows
 
 ## Global Instructions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,6 +328,9 @@ The SDK prioritizes **concurrency safety**:
 
 - Clients are immutable value types
 - Client methods snapshot the client's options on each call
+- Request DTOs are passed by value and never mutated by the SDK;
+  callers prevent caller-side races (for example via each DTO's
+  deep `Clone()` before concurrent invocation)
 - No shared mutable state between goroutines
 - All public APIs are safe for concurrent use
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,7 +327,7 @@ All of these are run by `./tools/build.sh`.
 The SDK prioritizes **concurrency safety**:
 
 - Clients are immutable value types
-- Services are lightweight snapshots of client options
+- Client methods snapshot the client's options on each call
 - No shared mutable state between goroutines
 - All public APIs are safe for concurrent use
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See the [examples](./examples) directory.
 - `Client` values are immutable; options are fixed at creation time to keep concurrency simple and request behavior predictable.
 - Each `Client` method call snapshots the client's options, so a single call is deterministic and never interferes with concurrent calls.
 - Clients are safe for concurrent use by default or when configured with immutable or synchronized dependencies.
+- Request DTOs are passed by value and the SDK never mutates the caller's payload. Treat a request (and the data it references) as read-only while a call is in flight; for concurrent invocation, pass a defensive copy per call via the deep `Clone()` method on each request DTO, or build a fresh request per call.
 - Per-request options can override client defaults for a single call.
 - The SDK favors upstream feature parity and uses DTOs closely aligned to the API; breaking changes are possible as the upstream API evolves.
 - `WithHTTPClientFactory` expects a fresh client value; avoid sharing mutable internals like transports unless synchronized to preserve safe concurrency.

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ See the [examples](./examples) directory.
 ### Design notes
 
 - `Client` values are immutable; options are fixed at creation time to keep concurrency simple and request behavior predictable.
-- Service values capture a snapshot of client options when created for deterministic behavior.
-- Clients and services are safe for concurrent use by default or when configured with immutable or synchronized dependencies.
+- Each `Client` method call snapshots the client's options, so a single call is deterministic and never interferes with concurrent calls.
+- Clients are safe for concurrent use by default or when configured with immutable or synchronized dependencies.
 - Per-request options can override client defaults for a single call.
 - The SDK favors upstream feature parity and uses DTOs closely aligned to the API; breaking changes are possible as the upstream API evolves.
 - `WithHTTPClientFactory` expects a fresh client value; avoid sharing mutable internals like transports unless synchronized to preserve safe concurrency.
 - `WithDefaultHTTPClient` restores the default client, while a nil factory is treated as a configuration error.
-- RawService exposes both error-interpreting and raw request paths (Do vs DoRaw).
+- `Client.Raw()` returns the `RawService` escape hatch for arbitrary endpoints, exposing both error-interpreting and raw request paths (Do vs DoRaw).
 - DTO validation is enforced during JSON marshal/unmarshal. Invalid request payloads surface as configuration errors. For responses, invalid content type surfaces as validation errors, while malformed JSON surfaces as serialization errors.
 
 ## Resources

--- a/chat_common.go
+++ b/chat_common.go
@@ -39,6 +39,17 @@ func (f *ChatFunctionCall) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Clone returns a deep defensive copy of the function call.
+func (f *ChatFunctionCall) Clone() ChatFunctionCall {
+	if f == nil {
+		return ChatFunctionCall{}
+	}
+	out := *f
+	out.Description = clonePtr(f.Description)
+
+	return out
+}
+
 func (f ChatFunctionCall) validate() error {
 	if f.Name == "" {
 		return &SDKError{

--- a/chat_common_test.go
+++ b/chat_common_test.go
@@ -81,3 +81,32 @@ func TestChatFunctionCall_Validation(t *testing.T) {
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindValidation)
 }
+
+func TestChatFunctionCallClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	fc := &ChatFunctionCall{
+		Name:        "fn",
+		Arguments:   "{}",
+		Description: testutils.Ptr("does things"),
+	}
+
+	cloned := fc.Clone()
+
+	*cloned.Description = "changed"
+	cloned.Name = "other"
+	cloned.Arguments = `{"x":1}`
+
+	require.Equal(t, "fn", fc.Name)
+	require.Equal(t, "{}", fc.Arguments)
+	require.Equal(t, "does things", *fc.Description)
+	require.Equal(t, "other", cloned.Name)
+	require.Equal(t, "changed", *cloned.Description)
+}
+
+func TestChatFunctionCallClone_Nil(t *testing.T) {
+	t.Parallel()
+
+	var f *ChatFunctionCall
+	require.Empty(t, f.Clone())
+}

--- a/chat_request.go
+++ b/chat_request.go
@@ -3,6 +3,7 @@ package hfgo
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 )
 
 // ChatRequest represents a completion request for the chat API.
@@ -97,6 +98,449 @@ func (r ChatRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(alias(r))
 }
 
+// Clone returns a deep defensive copy of the request. All reference fields —
+// slices, maps, pointers, and JSON blobs — are copied so the returned value
+// shares no backing storage with the receiver. This makes it safe to reuse a
+// template request across concurrent calls, e.g. go client.Chat(req.Clone(), ...).
+func (r *ChatRequest) Clone() ChatRequest {
+	if r == nil {
+		return ChatRequest{}
+	}
+	out := *r
+	out.Model = clonePtr(r.Model)
+	out.FrequencyPenalty = clonePtr(r.FrequencyPenalty)
+	out.LogProbs = clonePtr(r.LogProbs)
+	out.MaxTokens = clonePtr(r.MaxTokens)
+	out.Messages = cloneSlice(r.Messages, (*ChatMessage).Clone)
+	out.PresencePenalty = clonePtr(r.PresencePenalty)
+	out.ResponseFormat = cloneStructPtr(r.ResponseFormat, (*ChatResponseFormat).Clone)
+	out.Seed = clonePtr(r.Seed)
+	out.Stop = slices.Clone(r.Stop)
+	out.Stream = clonePtr(r.Stream)
+	out.StreamOptions = cloneStructPtr(r.StreamOptions, (*ChatStreamOptions).Clone)
+	out.Temperature = clonePtr(r.Temperature)
+	out.ToolChoice = cloneStructPtr(r.ToolChoice, (*ChatToolChoice).Clone)
+	out.ToolPrompt = clonePtr(r.ToolPrompt)
+	out.Tools = cloneSlice(r.Tools, (*ChatTool).Clone)
+	out.TopLogProbs = clonePtr(r.TopLogProbs)
+	out.TopP = clonePtr(r.TopP)
+
+	return out
+}
+
+// ChatMessage represents a single chat message.
+type ChatMessage struct {
+	// Role of the message author (for example: system, user, assistant, tool).
+	// Required.
+	Role string `json:"role"`
+	// Optional name for the participant.
+	Name *string `json:"name,omitempty"`
+
+	// Content may be a string or a list of content chunks.
+	// Either Content or ToolCalls should be supplied.
+	Content ChatMessageContent `json:"content"`
+
+	// ToolCalls is used instead of Content when providing tool call messages.
+	ToolCalls []ChatToolCall `json:"tool_calls,omitempty"`
+}
+
+// Clone returns a deep defensive copy of the message.
+func (m *ChatMessage) Clone() ChatMessage {
+	if m == nil {
+		return ChatMessage{}
+	}
+	out := *m
+	out.Name = clonePtr(m.Name)
+	out.Content = m.Content.Clone()
+	out.ToolCalls = cloneSlice(m.ToolCalls, (*ChatToolCall).Clone)
+
+	return out
+}
+
+// MarshalJSON enforces the union shape for ChatMessage.
+func (m ChatMessage) MarshalJSON() ([]byte, error) {
+	if err := m.validate(); err != nil {
+		return nil, err
+	}
+	type alias ChatMessage
+
+	return json.Marshal(alias(m))
+}
+
+// ChatMessageContent can be a string or []ChatMessageChunk.
+// Use a string for pure text content or a chunk list for multimodal content.
+type ChatMessageContent struct {
+	// NOTE: ChatMessageContent uses json:"-" on its fields because the JSON payload is
+	// a union (string or []ChatMessageChunk) handled by custom marshal/unmarshal.
+
+	// Text holds plain string content.
+	Text *string `json:"-"`
+	// Chunks holds structured content chunks.
+	Chunks []ChatMessageChunk `json:"-"`
+}
+
+// Clone returns a deep defensive copy of the content.
+func (c *ChatMessageContent) Clone() ChatMessageContent {
+	if c == nil {
+		return ChatMessageContent{}
+	}
+	out := *c
+	out.Text = clonePtr(c.Text)
+	out.Chunks = cloneSlice(c.Chunks, (*ChatMessageChunk).Clone)
+
+	return out
+}
+
+// MarshalJSON enforces the union shape for ChatMessageContent.
+func (c ChatMessageContent) MarshalJSON() ([]byte, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	if c.Text != nil {
+		return json.Marshal(*c.Text)
+	}
+	if c.Chunks != nil {
+		return json.Marshal(c.Chunks)
+	}
+
+	return []byte("null"), nil
+}
+
+// ChatMessageChunk represents a content chunk (text or image URL).
+// Type must be "text" with Text set, or "image_url" with ImageURL set.
+type ChatMessageChunk struct {
+	// Required when Type is "text".
+	Text *string `json:"text,omitempty"`
+	// Required when Type is "image_url".
+	ImageURL *ChatImageURL `json:"image_url,omitempty"`
+	// Required. Possible values: text, image_url.
+	Type MessageChunkType `json:"type"`
+}
+
+// Clone returns a deep defensive copy of the chunk.
+func (c *ChatMessageChunk) Clone() ChatMessageChunk {
+	if c == nil {
+		return ChatMessageChunk{}
+	}
+	out := *c
+	out.Text = clonePtr(c.Text)
+	out.ImageURL = cloneStructPtr(c.ImageURL, (*ChatImageURL).Clone)
+
+	return out
+}
+
+// MarshalJSON enforces the union shape for ChatMessageChunk.
+func (c ChatMessageChunk) MarshalJSON() ([]byte, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	type alias ChatMessageChunk
+
+	return json.Marshal(alias(c))
+}
+
+// ChatImageURL contains the URL for an image chunk.
+type ChatImageURL struct {
+	// Required.
+	URL string `json:"url"`
+}
+
+// Clone returns a defensive copy of the image URL.
+func (u *ChatImageURL) Clone() ChatImageURL {
+	if u == nil {
+		return ChatImageURL{}
+	}
+
+	return *u
+}
+
+// MarshalJSON enforces the required URL on ChatImageURL.
+func (u ChatImageURL) MarshalJSON() ([]byte, error) {
+	if err := u.validate(); err != nil {
+		return nil, err
+	}
+	type alias ChatImageURL
+
+	return json.Marshal(alias(u))
+}
+
+// MessageChunkType enumerates supported chat message chunk types.
+type MessageChunkType string
+
+const (
+	// MessageChunkTypeText represents a text chunk.
+	MessageChunkTypeText MessageChunkType = "text"
+	// MessageChunkTypeImageURL represents an image_url chunk.
+	MessageChunkTypeImageURL MessageChunkType = "image_url"
+)
+
+// ChatToolCall represents a tool call in a message.
+type ChatToolCall struct {
+	// Tool call ID.
+	// Required.
+	ID string `json:"id"`
+	// Tool call type (for example: function).
+	// Required.
+	Type string `json:"type"`
+	// Required.
+	Function ChatFunctionCall `json:"function"`
+}
+
+// Clone returns a deep defensive copy of the tool call.
+func (c *ChatToolCall) Clone() ChatToolCall {
+	if c == nil {
+		return ChatToolCall{}
+	}
+	out := *c
+	out.Function = c.Function.Clone()
+
+	return out
+}
+
+// MarshalJSON enforces the tool call shape for ChatToolCall.
+func (c ChatToolCall) MarshalJSON() ([]byte, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	type alias ChatToolCall
+
+	return json.Marshal(alias(c))
+}
+
+// ChatFunctionDefinition describes a callable function.
+type ChatFunctionDefinition struct {
+	// Required.
+	Name string `json:"name"`
+	// A description of what the function does.
+	Description *string `json:"description,omitempty"`
+	// JSON schema describing function parameters.
+	Parameters json.RawMessage `json:"parameters,omitempty"`
+}
+
+// Clone returns a deep defensive copy of the function definition.
+func (f *ChatFunctionDefinition) Clone() ChatFunctionDefinition {
+	if f == nil {
+		return ChatFunctionDefinition{}
+	}
+	out := *f
+	out.Description = clonePtr(f.Description)
+	out.Parameters = slices.Clone(f.Parameters)
+
+	return out
+}
+
+// MarshalJSON enforces required fields on ChatFunctionDefinition.
+func (f ChatFunctionDefinition) MarshalJSON() ([]byte, error) {
+	if err := f.validate(); err != nil {
+		return nil, err
+	}
+	type alias ChatFunctionDefinition
+
+	return json.Marshal(alias(f))
+}
+
+// ChatResponseFormat configures the response format.
+type ChatResponseFormat struct {
+	// Known type values: text, json_schema, json_object.
+	// Non-empty provider-specific values are also accepted.
+	// For json_schema, JSONSchema is required.
+	Type       ResponseFormatType    `json:"type"`
+	JSONSchema *ChatJSONSchemaConfig `json:"json_schema,omitempty"`
+}
+
+// Clone returns a deep defensive copy of the response format.
+func (r *ChatResponseFormat) Clone() ChatResponseFormat {
+	if r == nil {
+		return ChatResponseFormat{}
+	}
+	out := *r
+	out.JSONSchema = cloneStructPtr(r.JSONSchema, (*ChatJSONSchemaConfig).Clone)
+
+	return out
+}
+
+// ResponseFormatType enumerates known response formats.
+type ResponseFormatType string
+
+const (
+	// ResponseFormatTypeText requests a text response.
+	ResponseFormatTypeText ResponseFormatType = "text"
+	// ResponseFormatTypeJSONSchema requests a JSON schema response.
+	ResponseFormatTypeJSONSchema ResponseFormatType = "json_schema"
+	// ResponseFormatTypeJSONObject requests a JSON object response.
+	ResponseFormatTypeJSONObject ResponseFormatType = "json_object"
+)
+
+// MarshalJSON enforces the union shape for ChatResponseFormat.
+func (r ChatResponseFormat) MarshalJSON() ([]byte, error) {
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	type alias ChatResponseFormat
+
+	return json.Marshal(alias(r))
+}
+
+// ChatJSONSchemaConfig defines JSON schema response formatting.
+type ChatJSONSchemaConfig struct {
+	// The name of the response format.
+	// Required.
+	Name string `json:"name"`
+	// A description of what the response format is for.
+	Description *string `json:"description,omitempty"`
+	// The schema for the response format as a JSON Schema object.
+	// Learn how to build JSON schemas at https://json-schema.org/.
+	Schema json.RawMessage `json:"schema,omitempty"`
+	// Whether to enable strict schema adherence.
+	Strict *bool `json:"strict,omitempty"`
+}
+
+// Clone returns a deep defensive copy of the JSON schema configuration.
+func (c *ChatJSONSchemaConfig) Clone() ChatJSONSchemaConfig {
+	if c == nil {
+		return ChatJSONSchemaConfig{}
+	}
+	out := *c
+	out.Description = clonePtr(c.Description)
+	out.Schema = slices.Clone(c.Schema)
+	out.Strict = clonePtr(c.Strict)
+
+	return out
+}
+
+// ChatStreamOptions configures streaming behavior.
+type ChatStreamOptions struct {
+	// If set, an additional chunk is streamed before the [DONE] message
+	// showing overall usage. The usage field on this chunk shows the token
+	// usage statistics for the entire request, and the choices field will
+	// always be an empty array. All other chunks include a usage field with
+	// a null value.
+	IncludeUsage *bool `json:"include_usage,omitempty"`
+}
+
+// Clone returns a deep defensive copy of the stream options.
+func (o *ChatStreamOptions) Clone() ChatStreamOptions {
+	if o == nil {
+		return ChatStreamOptions{}
+	}
+	out := *o
+	out.IncludeUsage = clonePtr(o.IncludeUsage)
+
+	return out
+}
+
+// ChatTool represents a tool definition provided to the model.
+type ChatTool struct {
+	// Tool type (currently only function is supported).
+	Type     string                 `json:"type"`
+	Function ChatFunctionDefinition `json:"function"`
+}
+
+// MarshalJSON enforces the tool shape for ChatTool.
+func (t ChatTool) MarshalJSON() ([]byte, error) {
+	if err := t.validate(); err != nil {
+		return nil, err
+	}
+	type alias ChatTool
+
+	return json.Marshal(alias(t))
+}
+
+// Clone returns a deep defensive copy of the tool.
+func (t *ChatTool) Clone() ChatTool {
+	if t == nil {
+		return ChatTool{}
+	}
+	out := *t
+	out.Function = t.Function.Clone()
+
+	return out
+}
+
+// ChatToolChoice represents the tool choice union type.
+// Either Mode is set to auto/none/required, or Function is set.
+type ChatToolChoice struct {
+	// NOTE: ChatToolChoice uses json:"-" on its fields because the JSON payload is
+	// a union (string or {"function":{...}}) handled by custom marshal/unmarshal.
+
+	// Mode is a tool choice mode. Known values: auto, none, required.
+	// Non-empty provider-specific values are also accepted.
+	Mode *ToolChoiceMode `json:"-"`
+	// Function selects a specific tool function by name.
+	Function *ChatFunctionName `json:"-"`
+}
+
+// Clone returns a deep defensive copy of the tool choice.
+func (t *ChatToolChoice) Clone() ChatToolChoice {
+	if t == nil {
+		return ChatToolChoice{}
+	}
+	out := *t
+	out.Mode = clonePtr(t.Mode)
+	out.Function = cloneStructPtr(t.Function, (*ChatFunctionName).Clone)
+
+	return out
+}
+
+// ToolChoiceMode enumerates known tool choice modes.
+type ToolChoiceMode string
+
+const (
+	// ToolChoiceModeAuto lets the provider decide the tool choice.
+	ToolChoiceModeAuto ToolChoiceMode = "auto"
+	// ToolChoiceModeNone disables tool usage.
+	ToolChoiceModeNone ToolChoiceMode = "none"
+	// ToolChoiceModeRequired requires tool usage.
+	ToolChoiceModeRequired ToolChoiceMode = "required"
+)
+
+// toolChoiceFunctionPayload is the JSON object shape for function tool choices.
+type toolChoiceFunctionPayload struct {
+	Function *ChatFunctionName `json:"function"`
+}
+
+// MarshalJSON enforces the union shape for ChatToolChoice.
+func (t ChatToolChoice) MarshalJSON() ([]byte, error) {
+	if err := t.validate(); err != nil {
+		return nil, err
+	}
+	if t.Mode != nil {
+		return json.Marshal(*t.Mode)
+	}
+	if t.Function != nil {
+		return json.Marshal(toolChoiceFunctionPayload{
+			Function: t.Function,
+		})
+	}
+
+	return []byte("null"), nil
+}
+
+// ChatFunctionName identifies a tool function by name.
+type ChatFunctionName struct {
+	// Required.
+	Name string `json:"name"`
+}
+
+// MarshalJSON enforces required fields on ChatFunctionName.
+func (f ChatFunctionName) MarshalJSON() ([]byte, error) {
+	if err := f.validate(); err != nil {
+		return nil, err
+	}
+	type alias ChatFunctionName
+
+	return json.Marshal(alias(f))
+}
+
+// Clone returns a defensive copy of the function name.
+func (f *ChatFunctionName) Clone() ChatFunctionName {
+	if f == nil {
+		return ChatFunctionName{}
+	}
+
+	return *f
+}
+
 //nolint:gocritic // hugeParam: using a value receiver guarantees no modifications to the caller
 func (r ChatRequest) validate() error {
 	if r.Model == nil || *r.Model == "" {
@@ -116,32 +560,6 @@ func (r ChatRequest) validate() error {
 	}
 
 	return nil
-}
-
-// ChatMessage represents a single chat message.
-type ChatMessage struct {
-	// Role of the message author (for example: system, user, assistant, tool).
-	// Required.
-	Role string `json:"role"`
-	// Optional name for the participant.
-	Name *string `json:"name,omitempty"`
-
-	// Content may be a string or a list of content chunks.
-	// Either Content or ToolCalls should be supplied.
-	Content ChatMessageContent `json:"content"`
-
-	// ToolCalls is used instead of Content when providing tool call messages.
-	ToolCalls []ChatToolCall `json:"tool_calls,omitempty"`
-}
-
-// MarshalJSON enforces the union shape for ChatMessage.
-func (m ChatMessage) MarshalJSON() ([]byte, error) {
-	if err := m.validate(); err != nil {
-		return nil, err
-	}
-	type alias ChatMessage
-
-	return json.Marshal(alias(m))
 }
 
 // validate enforces the union shape for ChatMessage.
@@ -172,33 +590,6 @@ func (m ChatMessage) validate() error {
 	return nil
 }
 
-// ChatMessageContent can be a string or []ChatMessageChunk.
-// Use a string for pure text content or a chunk list for multimodal content.
-type ChatMessageContent struct {
-	// NOTE: ChatMessageContent uses json:"-" on its fields because the JSON payload is
-	// a union (string or []ChatMessageChunk) handled by custom marshal/unmarshal.
-
-	// Text holds plain string content.
-	Text *string `json:"-"`
-	// Chunks holds structured content chunks.
-	Chunks []ChatMessageChunk `json:"-"`
-}
-
-// MarshalJSON enforces the union shape for ChatMessageContent.
-func (c ChatMessageContent) MarshalJSON() ([]byte, error) {
-	if err := c.validate(); err != nil {
-		return nil, err
-	}
-	if c.Text != nil {
-		return json.Marshal(*c.Text)
-	}
-	if c.Chunks != nil {
-		return json.Marshal(c.Chunks)
-	}
-
-	return []byte("null"), nil
-}
-
 // validate enforces the union shape for ChatMessageContent.
 func (c ChatMessageContent) validate() error {
 	if c.Text != nil && len(c.Chunks) > 0 {
@@ -210,27 +601,6 @@ func (c ChatMessageContent) validate() error {
 	}
 
 	return nil
-}
-
-// ChatMessageChunk represents a content chunk (text or image URL).
-// Type must be "text" with Text set, or "image_url" with ImageURL set.
-type ChatMessageChunk struct {
-	// Required when Type is "text".
-	Text *string `json:"text,omitempty"`
-	// Required when Type is "image_url".
-	ImageURL *ChatImageURL `json:"image_url,omitempty"`
-	// Required. Possible values: text, image_url.
-	Type MessageChunkType `json:"type"`
-}
-
-// MarshalJSON enforces the union shape for ChatMessageChunk.
-func (c ChatMessageChunk) MarshalJSON() ([]byte, error) {
-	if err := c.validate(); err != nil {
-		return nil, err
-	}
-	type alias ChatMessageChunk
-
-	return json.Marshal(alias(c))
 }
 
 // validate enforces the union shape for ChatMessageChunk.
@@ -277,22 +647,6 @@ func (c ChatMessageChunk) validate() error {
 	return nil
 }
 
-// ChatImageURL contains the URL for an image chunk.
-type ChatImageURL struct {
-	// Required.
-	URL string `json:"url"`
-}
-
-// MarshalJSON enforces the required URL on ChatImageURL.
-func (u ChatImageURL) MarshalJSON() ([]byte, error) {
-	if err := u.validate(); err != nil {
-		return nil, err
-	}
-	type alias ChatImageURL
-
-	return json.Marshal(alias(u))
-}
-
 func (u ChatImageURL) validate() error {
 	if u.URL == "" {
 		return &SDKError{
@@ -303,38 +657,6 @@ func (u ChatImageURL) validate() error {
 	}
 
 	return nil
-}
-
-// MessageChunkType enumerates supported chat message chunk types.
-type MessageChunkType string
-
-const (
-	// MessageChunkTypeText represents a text chunk.
-	MessageChunkTypeText MessageChunkType = "text"
-	// MessageChunkTypeImageURL represents an image_url chunk.
-	MessageChunkTypeImageURL MessageChunkType = "image_url"
-)
-
-// ChatToolCall represents a tool call in a message.
-type ChatToolCall struct {
-	// Tool call ID.
-	// Required.
-	ID string `json:"id"`
-	// Tool call type (for example: function).
-	// Required.
-	Type string `json:"type"`
-	// Required.
-	Function ChatFunctionCall `json:"function"`
-}
-
-// MarshalJSON enforces the tool call shape for ChatToolCall.
-func (c ChatToolCall) MarshalJSON() ([]byte, error) {
-	if err := c.validate(); err != nil {
-		return nil, err
-	}
-	type alias ChatToolCall
-
-	return json.Marshal(alias(c))
 }
 
 // validate enforces the tool call shape for ChatToolCall.
@@ -357,26 +679,6 @@ func (c ChatToolCall) validate() error {
 	return nil
 }
 
-// ChatFunctionDefinition describes a callable function.
-type ChatFunctionDefinition struct {
-	// Required.
-	Name string `json:"name"`
-	// A description of what the function does.
-	Description *string `json:"description,omitempty"`
-	// JSON schema describing function parameters.
-	Parameters json.RawMessage `json:"parameters,omitempty"`
-}
-
-// MarshalJSON enforces required fields on ChatFunctionDefinition.
-func (f ChatFunctionDefinition) MarshalJSON() ([]byte, error) {
-	if err := f.validate(); err != nil {
-		return nil, err
-	}
-	type alias ChatFunctionDefinition
-
-	return json.Marshal(alias(f))
-}
-
 func (f ChatFunctionDefinition) validate() error {
 	if f.Name == "" {
 		return &SDKError{
@@ -387,37 +689,6 @@ func (f ChatFunctionDefinition) validate() error {
 	}
 
 	return nil
-}
-
-// ChatResponseFormat configures the response format.
-type ChatResponseFormat struct {
-	// Known type values: text, json_schema, json_object.
-	// Non-empty provider-specific values are also accepted.
-	// For json_schema, JSONSchema is required.
-	Type       ResponseFormatType    `json:"type"`
-	JSONSchema *ChatJSONSchemaConfig `json:"json_schema,omitempty"`
-}
-
-// ResponseFormatType enumerates known response formats.
-type ResponseFormatType string
-
-const (
-	// ResponseFormatTypeText requests a text response.
-	ResponseFormatTypeText ResponseFormatType = "text"
-	// ResponseFormatTypeJSONSchema requests a JSON schema response.
-	ResponseFormatTypeJSONSchema ResponseFormatType = "json_schema"
-	// ResponseFormatTypeJSONObject requests a JSON object response.
-	ResponseFormatTypeJSONObject ResponseFormatType = "json_object"
-)
-
-// MarshalJSON enforces the union shape for ChatResponseFormat.
-func (r ChatResponseFormat) MarshalJSON() ([]byte, error) {
-	if err := r.validate(); err != nil {
-		return nil, err
-	}
-	type alias ChatResponseFormat
-
-	return json.Marshal(alias(r))
 }
 
 // validate enforces the union shape for ChatResponseFormat.
@@ -465,47 +736,6 @@ func (r ChatResponseFormat) validate() error {
 	return nil
 }
 
-// ChatJSONSchemaConfig defines JSON schema response formatting.
-type ChatJSONSchemaConfig struct {
-	// The name of the response format.
-	// Required.
-	Name string `json:"name"`
-	// A description of what the response format is for.
-	Description *string `json:"description,omitempty"`
-	// The schema for the response format as a JSON Schema object.
-	// Learn how to build JSON schemas at https://json-schema.org/.
-	Schema json.RawMessage `json:"schema,omitempty"`
-	// Whether to enable strict schema adherence.
-	Strict *bool `json:"strict,omitempty"`
-}
-
-// ChatStreamOptions configures streaming behavior.
-type ChatStreamOptions struct {
-	// If set, an additional chunk is streamed before the [DONE] message
-	// showing overall usage. The usage field on this chunk shows the token
-	// usage statistics for the entire request, and the choices field will
-	// always be an empty array. All other chunks include a usage field with
-	// a null value.
-	IncludeUsage *bool `json:"include_usage,omitempty"`
-}
-
-// ChatTool represents a tool definition provided to the model.
-type ChatTool struct {
-	// Tool type (currently only function is supported).
-	Type     string                 `json:"type"`
-	Function ChatFunctionDefinition `json:"function"`
-}
-
-// MarshalJSON enforces the tool shape for ChatTool.
-func (t ChatTool) MarshalJSON() ([]byte, error) {
-	if err := t.validate(); err != nil {
-		return nil, err
-	}
-	type alias ChatTool
-
-	return json.Marshal(alias(t))
-}
-
 // validate enforces the tool shape for ChatTool.
 func (t ChatTool) validate() error {
 	if t.Type == "" {
@@ -517,53 +747,6 @@ func (t ChatTool) validate() error {
 	}
 
 	return nil
-}
-
-// ChatToolChoice represents the tool choice union type.
-// Either Mode is set to auto/none/required, or Function is set.
-type ChatToolChoice struct {
-	// NOTE: ChatToolChoice uses json:"-" on its fields because the JSON payload is
-	// a union (string or {"function":{...}}) handled by custom marshal/unmarshal.
-
-	// Mode is a tool choice mode. Known values: auto, none, required.
-	// Non-empty provider-specific values are also accepted.
-	Mode *ToolChoiceMode `json:"-"`
-	// Function selects a specific tool function by name.
-	Function *ChatFunctionName `json:"-"`
-}
-
-// ToolChoiceMode enumerates known tool choice modes.
-type ToolChoiceMode string
-
-const (
-	// ToolChoiceModeAuto lets the provider decide the tool choice.
-	ToolChoiceModeAuto ToolChoiceMode = "auto"
-	// ToolChoiceModeNone disables tool usage.
-	ToolChoiceModeNone ToolChoiceMode = "none"
-	// ToolChoiceModeRequired requires tool usage.
-	ToolChoiceModeRequired ToolChoiceMode = "required"
-)
-
-// toolChoiceFunctionPayload is the JSON object shape for function tool choices.
-type toolChoiceFunctionPayload struct {
-	Function *ChatFunctionName `json:"function"`
-}
-
-// MarshalJSON enforces the union shape for ChatToolChoice.
-func (t ChatToolChoice) MarshalJSON() ([]byte, error) {
-	if err := t.validate(); err != nil {
-		return nil, err
-	}
-	if t.Mode != nil {
-		return json.Marshal(*t.Mode)
-	}
-	if t.Function != nil {
-		return json.Marshal(toolChoiceFunctionPayload{
-			Function: t.Function,
-		})
-	}
-
-	return []byte("null"), nil
 }
 
 // validate enforces the union shape for ChatToolChoice.
@@ -584,22 +767,6 @@ func (t ChatToolChoice) validate() error {
 	}
 
 	return nil
-}
-
-// ChatFunctionName identifies a tool function by name.
-type ChatFunctionName struct {
-	// Required.
-	Name string `json:"name"`
-}
-
-// MarshalJSON enforces required fields on ChatFunctionName.
-func (f ChatFunctionName) MarshalJSON() ([]byte, error) {
-	if err := f.validate(); err != nil {
-		return nil, err
-	}
-	type alias ChatFunctionName
-
-	return json.Marshal(alias(f))
 }
 
 func (f ChatFunctionName) validate() error {

--- a/chat_request_test.go
+++ b/chat_request_test.go
@@ -228,6 +228,198 @@ func TestChatMessage_Validation(t *testing.T) {
 	}
 }
 
+func TestChatRequestClone_Deep_Scalars(t *testing.T) {
+	t.Parallel()
+
+	req := &ChatRequest{
+		Model:            testutils.Ptr("m"),
+		FrequencyPenalty: testutils.Ptr(0.5),
+		LogProbs:         testutils.Ptr(true),
+		MaxTokens:        testutils.Ptr(100),
+		PresencePenalty:  testutils.Ptr(-0.2),
+		Seed:             testutils.Ptr(int64(42)),
+		Stop:             []string{"x"},
+		Stream:           testutils.Ptr(false),
+		Temperature:      testutils.Ptr(1.0),
+		ToolPrompt:       testutils.Ptr("prompt"),
+		TopLogProbs:      testutils.Ptr(1),
+		TopP:             testutils.Ptr(0.9),
+	}
+
+	cloned := req.Clone()
+
+	*cloned.Model = "m2"
+	*cloned.FrequencyPenalty = 0.9
+	*cloned.LogProbs = false
+	*cloned.MaxTokens = 200
+	*cloned.PresencePenalty = 0.5
+	*cloned.Seed = 7
+	cloned.Stop[0] = "y"
+	*cloned.Stream = true
+	*cloned.Temperature = 2.0
+	*cloned.ToolPrompt = "changed"
+	*cloned.TopLogProbs = 5
+	*cloned.TopP = 0.1
+
+	require.Equal(t, "m", *req.Model)
+	require.InEpsilon(t, 0.5, *req.FrequencyPenalty, 0.001)
+	require.True(t, *req.LogProbs)
+	require.Equal(t, 100, *req.MaxTokens)
+	require.InEpsilon(t, -0.2, *req.PresencePenalty, 0.001)
+	require.Equal(t, int64(42), *req.Seed)
+	require.Equal(t, []string{"x"}, req.Stop)
+	require.False(t, *req.Stream)
+	require.InEpsilon(t, 1.0, *req.Temperature, 0.001)
+	require.Equal(t, "prompt", *req.ToolPrompt)
+	require.Equal(t, 1, *req.TopLogProbs)
+	require.InEpsilon(t, 0.9, *req.TopP, 0.001)
+}
+
+func TestChatRequestClone_Deep_Nested(t *testing.T) {
+	t.Parallel()
+
+	req := &ChatRequest{
+		Messages: []ChatMessage{
+			{Role: "assistant", ToolCalls: []ChatToolCall{
+				{
+					ID:   "id1",
+					Type: "function",
+					Function: ChatFunctionCall{
+						Name:        "fn",
+						Arguments:   "{}",
+						Description: testutils.Ptr("desc"),
+					},
+				},
+			}},
+			{Role: "user", Content: ChatMessageContent{Chunks: []ChatMessageChunk{
+				{
+					Type:     MessageChunkTypeImageURL,
+					ImageURL: &ChatImageURL{URL: "https://example.com/img.png"},
+				},
+				{Type: MessageChunkTypeText, Text: testutils.Ptr("hi")},
+			}}},
+		},
+		ResponseFormat: &ChatResponseFormat{
+			Type: ResponseFormatTypeJSONSchema,
+			JSONSchema: &ChatJSONSchemaConfig{
+				Name:        "n",
+				Description: testutils.Ptr("d"),
+				Strict:      testutils.Ptr(true),
+			},
+		},
+		StreamOptions: &ChatStreamOptions{IncludeUsage: testutils.Ptr(true)},
+		ToolChoice:    &ChatToolChoice{Function: &ChatFunctionName{Name: "fn"}},
+		Tools: []ChatTool{
+			{
+				Type: "function",
+				Function: ChatFunctionDefinition{
+					Name:        "f",
+					Description: testutils.Ptr("desc"),
+					Parameters:  json.RawMessage(`{"type":"object"}`),
+				},
+			},
+		},
+	}
+
+	cloned := req.Clone()
+
+	*cloned.Messages[0].ToolCalls[0].Function.Description = "changed"
+	cloned.Messages[1].Content.Chunks[0].ImageURL.URL = "https://example.com/other.png"
+	*cloned.Messages[1].Content.Chunks[1].Text = "changed"
+	*cloned.ResponseFormat.JSONSchema.Strict = false
+	*cloned.StreamOptions.IncludeUsage = false
+	cloned.ToolChoice.Function.Name = "other"
+	cloned.Tools[0].Function.Parameters = json.RawMessage(`{"type":"object"}zzz`)
+
+	require.Equal(t, "desc", *req.Messages[0].ToolCalls[0].Function.Description)
+	require.Equal(t, "https://example.com/img.png", req.Messages[1].Content.Chunks[0].ImageURL.URL)
+	require.Equal(t, "hi", *req.Messages[1].Content.Chunks[1].Text)
+	require.True(t, *req.ResponseFormat.JSONSchema.Strict)
+	require.True(t, *req.StreamOptions.IncludeUsage)
+	require.Equal(t, "fn", req.ToolChoice.Function.Name)
+	require.JSONEq(t, `{"type":"object"}`, string(req.Tools[0].Function.Parameters))
+}
+
+func TestChatRequestClone_Deep_JSONSchema(t *testing.T) {
+	t.Parallel()
+
+	schema := json.RawMessage(`{"type":"object"}`)
+	req := &ChatRequest{
+		Model: testutils.Ptr("m"),
+		Messages: []ChatMessage{
+			{Role: "user", Content: ChatMessageContent{Text: testutils.Ptr("hello")}},
+		},
+		Stop: []string{"x"},
+		Tools: []ChatTool{
+			{Type: "function", Function: ChatFunctionDefinition{Name: "f", Parameters: schema}},
+		},
+		ResponseFormat: &ChatResponseFormat{
+			Type:       ResponseFormatTypeJSONSchema,
+			JSONSchema: &ChatJSONSchemaConfig{Name: "n", Schema: schema},
+		},
+		ToolChoice: &ChatToolChoice{Mode: testutils.Ptr(ToolChoiceModeAuto)},
+	}
+
+	cloned := req.Clone()
+
+	*cloned.Messages[0].Content.Text = "changed"
+	cloned.Messages[0].Role = "assistant"
+	cloned.Stop[0] = "y"
+	cloned.Tools[0].Function.Parameters = json.RawMessage(`{"type":"object"}zzz`)
+	cloned.ResponseFormat.JSONSchema.Schema = json.RawMessage(`{"type":"object"}xxx`)
+	*cloned.ToolChoice.Mode = ToolChoiceModeNone
+
+	require.Equal(t, "hello", *req.Messages[0].Content.Text)
+	require.Equal(t, "user", req.Messages[0].Role)
+	require.Equal(t, []string{"x"}, req.Stop)
+	require.JSONEq(t, `{"type":"object"}`, string(req.Tools[0].Function.Parameters))
+	require.JSONEq(t, `{"type":"object"}`, string(req.ResponseFormat.JSONSchema.Schema))
+	require.Equal(t, ToolChoiceModeAuto, *req.ToolChoice.Mode)
+}
+
+func TestChatRequestClone_Nil(t *testing.T) {
+	t.Parallel()
+
+	var req *ChatRequest
+	require.Empty(t, req.Clone())
+
+	var m *ChatMessage
+	require.Empty(t, m.Clone())
+
+	var c *ChatMessageContent
+	require.Empty(t, c.Clone())
+
+	var chunk *ChatMessageChunk
+	require.Empty(t, chunk.Clone())
+
+	var u *ChatImageURL
+	require.Empty(t, u.Clone())
+
+	var tc *ChatToolCall
+	require.Empty(t, tc.Clone())
+
+	var fd *ChatFunctionDefinition
+	require.Empty(t, fd.Clone())
+
+	var rf *ChatResponseFormat
+	require.Empty(t, rf.Clone())
+
+	var cfg *ChatJSONSchemaConfig
+	require.Empty(t, cfg.Clone())
+
+	var so *ChatStreamOptions
+	require.Empty(t, so.Clone())
+
+	var tool *ChatTool
+	require.Empty(t, tool.Clone())
+
+	var choice *ChatToolChoice
+	require.Empty(t, choice.Clone())
+
+	var name *ChatFunctionName
+	require.Empty(t, name.Clone())
+}
+
 func TestChatRequest_MarshalSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/chat_service.go
+++ b/chat_service.go
@@ -13,37 +13,18 @@ import (
 // EndpointChatCompletion specifies the chat completion endpoint.
 const EndpointChatCompletion = "/v1/chat/completions"
 
-// ChatService implements chat completion calls using the configured request options.
-type ChatService struct {
+// chatService implements chat completion calls using the configured request options.
+type chatService struct {
 	opts request.Options
 }
 
 // newChatService builds a chat service with a snapshot of the provided options.
-func newChatService(opts request.Options) ChatService {
-	return ChatService{opts: opts}
+func newChatService(opts request.Options) chatService {
+	return chatService{opts: opts}
 }
 
-// Complete sends a chat completion request and returns a chat completion response.
-//
-// The caller must not mutate req while the request is being processed.
-// For safe concurrent usage, create a new ChatRequest for each concurrent call.
-//
-// Model Precedence:
-// The Model field is resolved with the following precedence (highest to lowest):
-//  1. ChatRequest.Model field (if non-nil and non-empty)
-//  2. Per-request options Model override
-//  3. Client-level Model option
-//
-// Provider Precedence:
-// The Provider field is applied as a fallback only if the resolved Model does not
-// already contain a provider (indicated by ":" in the model string). If the Model
-// is in the format "model:provider", the Provider option is ignored.
-//
-// For example:
-//   - Model="mistral-7b", Provider="huggingface" → "mistral-7b:huggingface"
-//   - Model="mistral-7b:huggingface", Provider="mistral" → "mistral-7b:huggingface" (Provider ignored)
-//   - Model="mistral-7b:huggingface", Provider="" → "mistral-7b:huggingface"
-func (s ChatService) Complete(req *ChatRequest, opts ...Option) (ChatResponse, error) {
+// complete sends a chat completion request and returns a chat completion response.
+func (s chatService) complete(req *ChatRequest, opts ...Option) (ChatResponse, error) {
 	if req == nil {
 		return ChatResponse{}, &SDKError{
 			Kind:    SDKErrorKindConfiguration,
@@ -60,7 +41,7 @@ func (s ChatService) Complete(req *ChatRequest, opts ...Option) (ChatResponse, e
 	if payload.Stream != nil && *payload.Stream {
 		return ChatResponse{}, &SDKError{
 			Kind:    SDKErrorKindConfiguration,
-			Message: "chat completion streaming is not supported by ChatService.Complete; use a streaming method instead",
+			Message: "chat completion streaming is not supported; use a streaming chat method instead",
 			Err:     nil,
 		}
 	}
@@ -73,29 +54,8 @@ func (s ChatService) Complete(req *ChatRequest, opts ...Option) (ChatResponse, e
 	)
 }
 
-// CompleteStream sends a chat completion request and returns a streaming response.
-// Callers should Close the returned ChatStream when finished so the underlying HTTP
-// connection and decoder goroutine are released promptly.
-//
-// The caller must not mutate req while the request is being processed.
-// For safe concurrent usage, create a new ChatRequest for each concurrent call.
-//
-// Model Precedence:
-// The Model field is resolved with the following precedence (highest to lowest):
-//  1. ChatRequest.Model field (if non-nil and non-empty)
-//  2. Per-request options Model override
-//  3. Client-level Model option
-//
-// Provider Precedence:
-// The Provider field is applied as a fallback only if the resolved Model does not
-// already contain a provider (indicated by ":" in the model string). If the Model
-// is in the format "model:provider", the Provider option is ignored.
-//
-// For example:
-//   - Model="mistral-7b", Provider="huggingface" → "mistral-7b:huggingface"
-//   - Model="mistral-7b:huggingface", Provider="mistral" → "mistral-7b:huggingface" (Provider ignored)
-//   - Model="mistral-7b:huggingface", Provider="" → "mistral-7b:huggingface"
-func (s ChatService) CompleteStream(req *ChatRequest, opts ...Option) (*ChatStream, error) {
+// completeStream sends a chat completion request and returns a streaming response.
+func (s chatService) completeStream(req *ChatRequest, opts ...Option) (*ChatStream, error) {
 	if req == nil {
 		return nil, &SDKError{
 			Kind:    SDKErrorKindConfiguration,

--- a/chat_service.go
+++ b/chat_service.go
@@ -24,21 +24,14 @@ func newChatService(opts request.Options) chatService {
 }
 
 // complete sends a chat completion request and returns a chat completion response.
-func (s chatService) complete(req *ChatRequest, opts ...Option) (ChatResponse, error) {
-	if req == nil {
-		return ChatResponse{}, &SDKError{
-			Kind:    SDKErrorKindConfiguration,
-			Message: "chat request is nil",
-			Err:     nil,
-		}
-	}
-
-	payload := *req
+//
+//nolint:gocritic // hugeParam: complete takes the request by value so the SDK never mutates the caller's payload
+func (s chatService) complete(req ChatRequest, opts ...Option) (ChatResponse, error) {
 	optsOverride := s.opts.With(opts...)
 
-	resolveModel(&payload, optsOverride)
+	resolveModel(&req, optsOverride)
 
-	if payload.Stream != nil && *payload.Stream {
+	if req.Stream != nil && *req.Stream {
 		return ChatResponse{}, &SDKError{
 			Kind:    SDKErrorKindConfiguration,
 			Message: "chat completion streaming is not supported; use a streaming chat method instead",
@@ -50,33 +43,26 @@ func (s chatService) complete(req *ChatRequest, opts ...Option) (ChatResponse, e
 		optsOverride,
 		http.MethodPost,
 		EndpointChatCompletion,
-		payload,
+		req,
 	)
 }
 
 // completeStream sends a chat completion request and returns a streaming response.
-func (s chatService) completeStream(req *ChatRequest, opts ...Option) (*ChatStream, error) {
-	if req == nil {
-		return nil, &SDKError{
-			Kind:    SDKErrorKindConfiguration,
-			Message: "chat request is nil",
-			Err:     nil,
-		}
-	}
-
-	payload := *req
+//
+//nolint:gocritic // hugeParam: completeStream takes the request by value so the SDK never mutates the caller's payload
+func (s chatService) completeStream(req ChatRequest, opts ...Option) (*ChatStream, error) {
 	optsOverride := s.opts.With(opts...)
 
-	resolveModel(&payload, optsOverride)
+	resolveModel(&req, optsOverride)
 
 	stream := true
-	payload.Stream = &stream
+	req.Stream = &stream
 
 	streamResp, err := request.DoJSONStream[ChatRequest, ChatStreamResponse](
 		optsOverride,
 		http.MethodPost,
 		EndpointChatCompletion,
-		payload,
+		req,
 	)
 	if err != nil {
 		return nil, err

--- a/chat_service_integration_test.go
+++ b/chat_service_integration_test.go
@@ -34,7 +34,7 @@ func TestChatCompletion_LiveAPI(t *testing.T) {
 
 	const text = "Say hello in one sentence."
 	resp, err := client.Chat(
-		&ChatRequest{
+		ChatRequest{
 			Messages: []ChatMessage{
 				{
 					Role: "user",
@@ -90,7 +90,7 @@ func TestChatCompletion_StreamingLiveAPI(t *testing.T) {
 
 	text := "Say hello in one sentence."
 	stream, err := client.ChatStream(
-		&ChatRequest{
+		ChatRequest{
 			Messages: []ChatMessage{
 				{
 					Role: "user",
@@ -153,7 +153,7 @@ func TestChatCompletion_MultiMessageLiveAPI(t *testing.T) {
 	text2 := "What is the answer multiplied by 3?"
 
 	resp, err := client.Chat(
-		&ChatRequest{
+		ChatRequest{
 			Messages: []ChatMessage{
 				{
 					Role: "user",

--- a/chat_service_integration_test.go
+++ b/chat_service_integration_test.go
@@ -33,7 +33,7 @@ func TestChatCompletion_LiveAPI(t *testing.T) {
 	)
 
 	const text = "Say hello in one sentence."
-	resp, err := client.Chat().Complete(
+	resp, err := client.Chat(
 		&ChatRequest{
 			Messages: []ChatMessage{
 				{
@@ -89,7 +89,7 @@ func TestChatCompletion_StreamingLiveAPI(t *testing.T) {
 	)
 
 	text := "Say hello in one sentence."
-	stream, err := client.Chat().CompleteStream(
+	stream, err := client.ChatStream(
 		&ChatRequest{
 			Messages: []ChatMessage{
 				{
@@ -152,7 +152,7 @@ func TestChatCompletion_MultiMessageLiveAPI(t *testing.T) {
 	text1 := "What is 2+2?"
 	text2 := "What is the answer multiplied by 3?"
 
-	resp, err := client.Chat().Complete(
+	resp, err := client.Chat(
 		&ChatRequest{
 			Messages: []ChatMessage{
 				{

--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -65,9 +65,9 @@ func TestChatService_Complete_ModelSelection(t *testing.T) {
 
 			var err error
 			if tc.optsModel != "" {
-				_, err = svc.Complete(req, WithModel(tc.optsModel))
+				_, err = svc.complete(req, WithModel(tc.optsModel))
 			} else {
-				_, err = svc.Complete(req)
+				_, err = svc.complete(req)
 			}
 
 			require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestChatService_Complete_ModelValidation(t *testing.T) {
 		},
 	}
 
-	_, err := svc.Complete(req)
+	_, err := svc.complete(req)
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -117,7 +117,7 @@ func TestChatService_Complete_NilRequest(t *testing.T) {
 		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
 	svc := newChatService(opts)
 
-	_, err := svc.Complete(nil)
+	_, err := svc.complete(nil)
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -140,7 +140,7 @@ func TestChatService_Complete_StreamNotAllowed(t *testing.T) {
 		},
 	}
 
-	_, err := svc.Complete(req)
+	_, err := svc.complete(req)
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -166,7 +166,7 @@ func TestChatService_CompleteStream_Success(t *testing.T) {
 		},
 	}
 
-	stream, err := svc.CompleteStream(req)
+	stream, err := svc.completeStream(req)
 	require.NoError(t, err)
 	defer func() { _ = stream.Close() }()
 
@@ -257,7 +257,7 @@ func TestChatStream_Recv_InvalidJSONError(t *testing.T) {
 		},
 	}
 
-	stream, err := svc.CompleteStream(req)
+	stream, err := svc.completeStream(req)
 	require.NoError(t, err)
 	defer func() { _ = stream.Close() }()
 
@@ -293,7 +293,7 @@ func assertToolCallStream(
 		},
 	}
 
-	stream, err := svc.CompleteStream(req)
+	stream, err := svc.completeStream(req)
 	require.NoError(t, err)
 	defer func() { _ = stream.Close() }()
 
@@ -319,7 +319,7 @@ func TestChatService_CompleteStream_NilRequest(t *testing.T) {
 		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
 	svc := newChatService(opts)
 
-	_, err := svc.CompleteStream(nil)
+	_, err := svc.completeStream(nil)
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -679,7 +679,7 @@ func TestChatService_ProviderFallback(t *testing.T) {
 		t *testing.T,
 		tc TestCase,
 		mtFactory func() *testutils.MockTransport,
-		methodCall func(*ChatService, *ChatRequest, []Option) error,
+		methodCall func(*chatService, *ChatRequest, []Option) error,
 	) {
 		t.Helper()
 
@@ -727,8 +727,8 @@ func TestChatService_ProviderFallback(t *testing.T) {
 						nil,
 					)
 				},
-				func(svc *ChatService, req *ChatRequest, opts []Option) error {
-					_, err := svc.Complete(req, opts...)
+				func(svc *chatService, req *ChatRequest, opts []Option) error {
+					_, err := svc.complete(req, opts...)
 
 					return err
 				},
@@ -744,8 +744,8 @@ func TestChatService_ProviderFallback(t *testing.T) {
 
 					return mt
 				},
-				func(svc *ChatService, req *ChatRequest, opts []Option) error {
-					stream, err := svc.CompleteStream(req, opts...)
+				func(svc *chatService, req *ChatRequest, opts []Option) error {
+					stream, err := svc.completeStream(req, opts...)
 					if err != nil {
 						return err
 					}

--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -69,10 +69,12 @@ func TestChatService_Complete_ModelSelection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, chatServiceResponseBody, nil)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel(tc.clientModel),
 			)
-			req := &ChatRequest{
+			req := ChatRequest{
 				Model: tc.reqModel,
 				Messages: []ChatMessage{
 					{Role: "user", Content: ChatMessageContent{Text: &text}},
@@ -113,7 +115,7 @@ func TestChatService_Complete_ModelValidation(t *testing.T) {
 	)
 
 	text := "hi"
-	req := &ChatRequest{
+	req := ChatRequest{
 		Messages: []ChatMessage{
 			{Role: "user", Content: ChatMessageContent{Text: &text}},
 		},
@@ -125,7 +127,7 @@ func TestChatService_Complete_ModelValidation(t *testing.T) {
 	require.Nil(t, mt.LastRequest)
 }
 
-func TestChatService_Complete_NilRequest(t *testing.T) {
+func TestChatService_Complete_ZeroValueRequest(t *testing.T) {
 	t.Parallel()
 
 	mt := testutils.NewJSONMockTransport(http.StatusOK, chatServiceResponseBody, nil)
@@ -133,7 +135,7 @@ func TestChatService_Complete_NilRequest(t *testing.T) {
 		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
 	)
 
-	_, err := client.Chat(nil)
+	_, err := client.Chat(ChatRequest{})
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -149,7 +151,7 @@ func TestChatService_Complete_StreamNotAllowed(t *testing.T) {
 
 	text := "hi"
 	stream := true
-	req := &ChatRequest{
+	req := ChatRequest{
 		Stream: &stream,
 		Messages: []ChatMessage{
 			{Role: "user", Content: ChatMessageContent{Text: &text}},
@@ -176,7 +178,7 @@ func TestChatService_CompleteStream_Success(t *testing.T) {
 	)
 
 	text := "hi"
-	req := &ChatRequest{
+	req := ChatRequest{
 		Messages: []ChatMessage{
 			{Role: "user", Content: ChatMessageContent{Text: &text}},
 		},
@@ -267,7 +269,7 @@ func TestChatStream_Recv_InvalidJSONError(t *testing.T) {
 	)
 
 	text := "hi"
-	req := &ChatRequest{
+	req := ChatRequest{
 		Messages: []ChatMessage{
 			{Role: "user", Content: ChatMessageContent{Text: &text}},
 		},
@@ -303,7 +305,7 @@ func assertToolCallStream(
 	)
 
 	text := "hi"
-	req := &ChatRequest{
+	req := ChatRequest{
 		Messages: []ChatMessage{
 			{Role: "user", Content: ChatMessageContent{Text: &text}},
 		},
@@ -326,7 +328,7 @@ func assertToolCallStream(
 	assertions(chunks)
 }
 
-func TestChatService_CompleteStream_NilRequest(t *testing.T) {
+func TestChatService_CompleteStream_ZeroValueRequest(t *testing.T) {
 	t.Parallel()
 
 	mt := testutils.NewMockTransport(http.StatusOK, "", nil)
@@ -335,7 +337,7 @@ func TestChatService_CompleteStream_NilRequest(t *testing.T) {
 		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
 	)
 
-	_, err := client.ChatStream(nil)
+	_, err := client.ChatStream(ChatRequest{})
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -695,7 +697,7 @@ func TestChatService_ProviderFallback(t *testing.T) {
 		t *testing.T,
 		tc TestCase,
 		mtFactory func() *testutils.MockTransport,
-		methodCall func(*Client, *ChatRequest, []Option) error,
+		methodCall func(*Client, ChatRequest, []Option) error,
 	) {
 		t.Helper()
 
@@ -707,7 +709,7 @@ func TestChatService_ProviderFallback(t *testing.T) {
 		)
 
 		text := "hi"
-		req := &ChatRequest{
+		req := ChatRequest{
 			Model: tc.reqModel,
 			Messages: []ChatMessage{
 				{Role: "user", Content: ChatMessageContent{Text: &text}},
@@ -743,7 +745,7 @@ func TestChatService_ProviderFallback(t *testing.T) {
 						nil,
 					)
 				},
-				func(client *Client, req *ChatRequest, opts []Option) error {
+				func(client *Client, req ChatRequest, opts []Option) error {
 					_, err := client.Chat(req, opts...)
 
 					return err
@@ -760,7 +762,7 @@ func TestChatService_ProviderFallback(t *testing.T) {
 
 					return mt
 				},
-				func(client *Client, req *ChatRequest, opts []Option) error {
+				func(client *Client, req ChatRequest, opts []Option) error {
 					stream, err := client.ChatStream(req, opts...)
 					if err != nil {
 						return err

--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -11,11 +11,27 @@ import (
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
 	"github.com/Kardbord/hfgo/v4/internal/request"
+	"github.com/Kardbord/hfgo/v4/internal/sdkversion"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 const chatServiceResponseBody = `{"id":"id","created":1,"model":"m","system_fingerprint":"s","choices":[{"finish_reason":"stop","index":0,"message":{"role":"assistant","content":"hi"}}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`
+
+func TestNewClient_Defaults(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient()
+
+	require.Equal(t, request.DefaultBaseURL, client.opts.BaseURL)
+	require.Equal(t, request.DefaultToken, client.opts.Token)
+	require.Equal(t, request.DefaultModel, client.opts.Model)
+	require.Equal(t, request.DefaultProvider, client.opts.Provider)
+	require.Equal(t, request.DefaultMaxResponseBodyBytes, client.opts.MaxResponseBodyBytes)
+	require.Equal(t, sdkversion.UserAgent(), client.opts.UserAgent)
+	require.Nil(t, client.opts.Headers)
+	require.NotNil(t, client.opts.HTTPClient)
+}
 
 func TestChatService_Complete_ModelSelection(t *testing.T) {
 	t.Parallel()
@@ -52,10 +68,10 @@ func TestChatService_Complete_ModelSelection(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, chatServiceResponseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel(tc.clientModel)
-			svc := newChatService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel(tc.clientModel),
+			)
 			req := &ChatRequest{
 				Model: tc.reqModel,
 				Messages: []ChatMessage{
@@ -65,9 +81,9 @@ func TestChatService_Complete_ModelSelection(t *testing.T) {
 
 			var err error
 			if tc.optsModel != "" {
-				_, err = svc.complete(req, WithModel(tc.optsModel))
+				_, err = client.Chat(req, WithModel(tc.optsModel))
 			} else {
-				_, err = svc.complete(req)
+				_, err = client.Chat(req)
 			}
 
 			require.NoError(t, err)
@@ -92,9 +108,9 @@ func TestChatService_Complete_ModelValidation(t *testing.T) {
 	t.Parallel()
 
 	mt := testutils.NewJSONMockTransport(http.StatusOK, chatServiceResponseBody, nil)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newChatService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
 	text := "hi"
 	req := &ChatRequest{
@@ -103,7 +119,7 @@ func TestChatService_Complete_ModelValidation(t *testing.T) {
 		},
 	}
 
-	_, err := svc.complete(req)
+	_, err := client.Chat(req)
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -113,11 +129,11 @@ func TestChatService_Complete_NilRequest(t *testing.T) {
 	t.Parallel()
 
 	mt := testutils.NewJSONMockTransport(http.StatusOK, chatServiceResponseBody, nil)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newChatService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
-	_, err := svc.complete(nil)
+	_, err := client.Chat(nil)
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -127,9 +143,9 @@ func TestChatService_Complete_StreamNotAllowed(t *testing.T) {
 	t.Parallel()
 
 	mt := testutils.NewJSONMockTransport(http.StatusOK, chatServiceResponseBody, nil)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newChatService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
 	text := "hi"
 	stream := true
@@ -140,7 +156,7 @@ func TestChatService_Complete_StreamNotAllowed(t *testing.T) {
 		},
 	}
 
-	_, err := svc.complete(req)
+	_, err := client.Chat(req)
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -154,10 +170,10 @@ func TestChatService_CompleteStream_Success(t *testing.T) {
 	mt := testutils.NewMockTransport(http.StatusOK, body, nil)
 	mt.Response.Header.Set("Content-Type", "text/event-stream")
 
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-		WithModel("default-model")
-	svc := newChatService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+		WithModel("default-model"),
+	)
 
 	text := "hi"
 	req := &ChatRequest{
@@ -166,7 +182,7 @@ func TestChatService_CompleteStream_Success(t *testing.T) {
 		},
 	}
 
-	stream, err := svc.completeStream(req)
+	stream, err := client.ChatStream(req)
 	require.NoError(t, err)
 	defer func() { _ = stream.Close() }()
 
@@ -245,10 +261,10 @@ func TestChatStream_Recv_InvalidJSONError(t *testing.T) {
 	mt := testutils.NewMockTransport(http.StatusOK, body, nil)
 	mt.Response.Header.Set("Content-Type", "text/event-stream")
 
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-		WithModel("default-model")
-	svc := newChatService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+		WithModel("default-model"),
+	)
 
 	text := "hi"
 	req := &ChatRequest{
@@ -257,7 +273,7 @@ func TestChatStream_Recv_InvalidJSONError(t *testing.T) {
 		},
 	}
 
-	stream, err := svc.completeStream(req)
+	stream, err := client.ChatStream(req)
 	require.NoError(t, err)
 	defer func() { _ = stream.Close() }()
 
@@ -281,10 +297,10 @@ func assertToolCallStream(
 	mt := testutils.NewMockTransport(http.StatusOK, body, nil)
 	mt.Response.Header.Set("Content-Type", "text/event-stream")
 
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-		WithModel("default-model")
-	svc := newChatService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+		WithModel("default-model"),
+	)
 
 	text := "hi"
 	req := &ChatRequest{
@@ -293,7 +309,7 @@ func assertToolCallStream(
 		},
 	}
 
-	stream, err := svc.completeStream(req)
+	stream, err := client.ChatStream(req)
 	require.NoError(t, err)
 	defer func() { _ = stream.Close() }()
 
@@ -315,11 +331,11 @@ func TestChatService_CompleteStream_NilRequest(t *testing.T) {
 
 	mt := testutils.NewMockTransport(http.StatusOK, "", nil)
 	mt.Response.Header.Set("Content-Type", "text/event-stream")
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newChatService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
-	_, err := svc.completeStream(nil)
+	_, err := client.ChatStream(nil)
 	require.Error(t, err)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 	require.Nil(t, mt.LastRequest)
@@ -679,16 +695,16 @@ func TestChatService_ProviderFallback(t *testing.T) {
 		t *testing.T,
 		tc TestCase,
 		mtFactory func() *testutils.MockTransport,
-		methodCall func(*chatService, *ChatRequest, []Option) error,
+		methodCall func(*Client, *ChatRequest, []Option) error,
 	) {
 		t.Helper()
 
 		mt := mtFactory()
-		opts := request.NewOptions().
-			WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-			WithModel(tc.clientModel).
-			WithProvider(tc.clientProvider)
-		svc := newChatService(opts)
+		client := NewClient(
+			WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+			WithModel(tc.clientModel),
+			WithProvider(tc.clientProvider),
+		)
 
 		text := "hi"
 		req := &ChatRequest{
@@ -706,7 +722,7 @@ func TestChatService_ProviderFallback(t *testing.T) {
 			optsToPass = append(optsToPass, WithProvider(*tc.optsProvider))
 		}
 
-		err := methodCall(&svc, req, optsToPass)
+		err := methodCall(&client, req, optsToPass)
 		require.NoError(t, err)
 
 		require.NotNil(t, mt.LastRequest)
@@ -727,8 +743,8 @@ func TestChatService_ProviderFallback(t *testing.T) {
 						nil,
 					)
 				},
-				func(svc *chatService, req *ChatRequest, opts []Option) error {
-					_, err := svc.complete(req, opts...)
+				func(client *Client, req *ChatRequest, opts []Option) error {
+					_, err := client.Chat(req, opts...)
 
 					return err
 				},
@@ -744,8 +760,8 @@ func TestChatService_ProviderFallback(t *testing.T) {
 
 					return mt
 				},
-				func(svc *chatService, req *ChatRequest, opts []Option) error {
-					stream, err := svc.completeStream(req, opts...)
+				func(client *Client, req *ChatRequest, opts []Option) error {
+					stream, err := client.ChatStream(req, opts...)
 					if err != nil {
 						return err
 					}

--- a/client.go
+++ b/client.go
@@ -104,13 +104,28 @@ func (c Client) ClassifyTextBatch(req TextClassificationBatchRequest, opts ...Op
 	return newTextClassificationService(c.opts).classifyBatch(req, opts...)
 }
 
-// ZeroShotClassifyText returns a ZeroShotClassificationService instance configured with this client's options.
-// The classification service provides methods for interacting with zero-shot text classification endpoints.
-// Service configurations are captured at creation time and do not change if the client options change later.
-// Clients are immutable to keep concurrency simple and request behavior predictable.
-// Services are lightweight; prefer to call ZeroShotClassifyText() per use instead of retaining the value.
-func (c Client) ZeroShotClassifyText() ZeroShotTextClassificationService {
-	return newZeroShotTextClassificationService(c.opts)
+// ZeroShotClassifyText sends a zero-shot text classification request and
+// returns the zero-shot text classification response for a single input.
+//
+// For multiple inputs, use ZeroShotClassifyTextBatch.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) ZeroShotClassifyText(req ZeroShotTextClassificationRequest, opts ...Option) ([]ZeroShotTextClassification, error) {
+	return newZeroShotTextClassificationService(c.opts).classify(req, opts...)
+}
+
+// ZeroShotClassifyTextBatch sends a zero-shot text classification request for
+// a batch of inputs and returns a list of zero-shot text classification
+// responses for each input in the batch.
+//
+// NOTE: Batched inference is supported by the upstream API, but is not
+// officially documented; behavior may change without notice.
+//
+// Callers should check the length of the response list before indexing.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) ZeroShotClassifyTextBatch(req ZeroShotTextClassificationBatchRequest, opts ...Option) ([][]ZeroShotTextClassification, error) {
+	return newZeroShotTextClassificationService(c.opts).classifyBatch(req, opts...)
 }
 
 // FillMask sends a fill mask request and returns the mask filling predictions

--- a/client.go
+++ b/client.go
@@ -99,13 +99,27 @@ func (c Client) ZeroShotClassifyText() ZeroShotTextClassificationService {
 	return newZeroShotTextClassificationService(c.opts)
 }
 
-// FillMask returns a FillMaskService instance configured with this client's options.
-// The fill mask service provides methods for interacting with fill mask endpoints.
-// Service configurations are captured at creation time and do not change if the client options change later.
-// Clients are immutable to keep concurrency simple and request behavior predictable.
-// Services are lightweight; prefer to call FillMask() per use instead of retaining the value.
-func (c Client) FillMask() FillMaskService {
-	return newFillMaskService(c.opts)
+// FillMask sends a fill mask request and returns the mask filling predictions
+// for a single input.
+//
+// For multiple inputs, use FillMaskBatch.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) FillMask(req FillMaskRequest, opts ...Option) ([]FillMaskPrediction, error) {
+	return newFillMaskService(c.opts).fill(req, opts...)
+}
+
+// FillMaskBatch sends a fill mask request for a batch of inputs and returns a
+// list of mask filling predictions for each input in the batch.
+//
+// NOTE: Batched inference is supported by the upstream API, but is not
+// officially documented; behavior may change without notice.
+//
+// Callers should check the length of the response list before indexing.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) FillMaskBatch(req FillMaskBatchRequest, opts ...Option) ([][]FillMaskPrediction, error) {
+	return newFillMaskService(c.opts).fillBatch(req, opts...)
 }
 
 // Summarization returns a SummarizationService instance configured with this client's options.

--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 // This keeps client usage safe across goroutines and avoids surprises from mutable state.
 // If options include externally-owned pointers, callers must avoid mutating them after creation
 // or ensure their own synchronization.
-// Services capture a snapshot of these options when created.
+// RawService captures a snapshot of these options when created.
 type Client struct {
 	opts request.Options
 }
@@ -178,11 +178,15 @@ func (c Client) SummarizeBatch(req SummarizationBatchRequest, opts ...Option) ([
 	return newSummarizationService(c.opts).summarizeBatch(req, opts...)
 }
 
-// Raw returns a RawService instance configured with this client's options.
-// The raw service provides methods for sending raw HTTP requests to any desired endpoint.
-// Service configurations are captured at creation time and do not change if the client options change later.
-// Clients are immutable to keep concurrency simple and request behavior predictable.
-// Services are lightweight; prefer to call Raw() per use instead of retaining the value.
+// Raw returns the raw HTTP request service for this client. Unlike the other
+// endpoints, which are exposed directly as Client methods, the raw path remains
+// namespaced under RawService: it is the advanced escape hatch for endpoints the
+// SDK does not otherwise cover, and its several method variants are easier to
+// discover grouped together than splashed across the Client surface.
+//
+// RawService is immutable and captures a snapshot of the client options when
+// created; it is lightweight, so prefer calling Raw() per use rather than
+// retaining the value.
 func (c Client) Raw() RawService {
 	return newRawService(c.opts)
 }

--- a/client.go
+++ b/client.go
@@ -81,13 +81,27 @@ func (c Client) ChatStream(req *ChatRequest, opts ...Option) (*ChatStream, error
 	return newChatService(c.opts).completeStream(req, opts...)
 }
 
-// ClassifyText returns a TextClassificationService instance configured with this client's options.
-// The classification service provides methods for interacting with text classification endpoints.
-// Service configurations are captured at creation time and do not change if the client options change later.
-// Clients are immutable to keep concurrency simple and request behavior predictable.
-// Services are lightweight; prefer to call ClassifyText() per use instead of retaining the value.
-func (c Client) ClassifyText() TextClassificationService {
-	return newTextClassificationService(c.opts)
+// ClassifyText sends a text classification request and returns the text
+// classification response for a single input.
+//
+// For multiple classification inputs, use ClassifyTextBatch.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) ClassifyText(req TextClassificationRequest, opts ...Option) ([]TextClassification, error) {
+	return newTextClassificationService(c.opts).classify(req, opts...)
+}
+
+// ClassifyTextBatch sends a text classification request for a batch of inputs
+// and returns a list of text classification responses for each input in the batch.
+//
+// NOTE: Batched inference is supported by the upstream API, but is not
+// officially documented; behavior may change without notice.
+//
+// Callers should check the length of the response list before indexing.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) ClassifyTextBatch(req TextClassificationBatchRequest, opts ...Option) ([][]TextClassification, error) {
+	return newTextClassificationService(c.opts).classifyBatch(req, opts...)
 }
 
 // ZeroShotClassifyText returns a ZeroShotClassificationService instance configured with this client's options.

--- a/client.go
+++ b/client.go
@@ -23,13 +23,62 @@ func NewClient(opts ...Option) Client {
 	}
 }
 
-// Chat returns a ChatService instance configured with this client's options.
-// The chat service provides methods for interacting with chat completion endpoints.
-// Service configurations are captured at creation time and do not change if the client options change later.
-// Clients are immutable to keep concurrency simple and request behavior predictable.
-// Services are lightweight; prefer to call Chat() per use instead of retaining the value.
-func (c Client) Chat() ChatService {
-	return newChatService(c.opts)
+// Chat sends a chat completion request and returns a chat completion response.
+//
+// The caller must not mutate req while the request is being processed.
+// For safe concurrent usage, create a new ChatRequest for each concurrent call.
+//
+// Model Precedence:
+// The Model field is resolved with the following precedence (highest to lowest):
+//  1. ChatRequest.Model field (if non-nil and non-empty)
+//  2. Per-request options Model override
+//  3. Client-level Model option
+//
+// Provider Precedence:
+// The Provider field is applied as a fallback only if the resolved Model does not
+// already contain a provider (indicated by ":" in the model string). If the Model
+// is in the format "model:provider", the Provider option is ignored.
+//
+// For example:
+//   - Model="mistral-7b", Provider="huggingface" → "mistral-7b:huggingface"
+//   - Model="mistral-7b:huggingface", Provider="mistral" → "mistral-7b:huggingface" (Provider ignored)
+//   - Model="mistral-7b:huggingface", Provider="" → "mistral-7b:huggingface"
+//
+// Behavior:
+//   - Returns a configuration error if req is nil.
+//   - Returns a configuration error if *req.Stream is true; use ChatStream for streaming.
+func (c Client) Chat(req *ChatRequest, opts ...Option) (ChatResponse, error) {
+	return newChatService(c.opts).complete(req, opts...)
+}
+
+// ChatStream sends a chat completion request and returns a streaming response.
+// Callers should Close the returned ChatStream when finished so the underlying HTTP
+// connection and decoder goroutine are released promptly.
+//
+// The caller must not mutate req while the request is being processed.
+// For safe concurrent usage, create a new ChatRequest for each concurrent call.
+//
+// Model Precedence:
+// The Model field is resolved with the following precedence (highest to lowest):
+//  1. ChatRequest.Model field (if non-nil and non-empty)
+//  2. Per-request options Model override
+//  3. Client-level Model option
+//
+// Provider Precedence:
+// The Provider field is applied as a fallback only if the resolved Model does not
+// already contain a provider (indicated by ":" in the model string). If the Model
+// is in the format "model:provider", the Provider option is ignored.
+//
+// For example:
+//   - Model="mistral-7b", Provider="huggingface" → "mistral-7b:huggingface"
+//   - Model="mistral-7b:huggingface", Provider="mistral" → "mistral-7b:huggingface" (Provider ignored)
+//   - Model="mistral-7b:huggingface", Provider="" → "mistral-7b:huggingface"
+//
+// Behavior:
+//   - Returns a configuration error if req is nil.
+//   - Always sends the request with streaming enabled.
+func (c Client) ChatStream(req *ChatRequest, opts ...Option) (*ChatStream, error) {
+	return newChatService(c.opts).completeStream(req, opts...)
 }
 
 // ClassifyText returns a TextClassificationService instance configured with this client's options.

--- a/client.go
+++ b/client.go
@@ -25,8 +25,17 @@ func NewClient(opts ...Option) Client {
 
 // Chat sends a chat completion request and returns a chat completion response.
 //
-// The caller must not mutate req while the request is being processed.
-// For safe concurrent usage, create a new ChatRequest for each concurrent call.
+// The request is passed by value and the SDK never mutates the received
+// payload. The value copy shares the request's nested data (slices, maps, and
+// pointed-to values) with the caller, so the caller must treat the request and
+// the data it references as read-only while a call is in flight.
+//
+// Concurrency:
+//   - A single Client is safe for concurrent use.
+//   - Reusing one request across sequential, fully-awaited calls is safe.
+//   - To invoke the same template request from multiple goroutines, pass a
+//     defensive copy per call, e.g. go client.Chat(req.Clone(), ...), or build a
+//     fresh request per call.
 //
 // Model Precedence:
 // The Model field is resolved with the following precedence (highest to lowest):
@@ -45,9 +54,11 @@ func NewClient(opts ...Option) Client {
 //   - Model="mistral-7b:huggingface", Provider="" → "mistral-7b:huggingface"
 //
 // Behavior:
-//   - Returns a configuration error if req is nil.
+//   - Returns a configuration error if the request is missing a model or messages.
 //   - Returns a configuration error if *req.Stream is true; use ChatStream for streaming.
-func (c Client) Chat(req *ChatRequest, opts ...Option) (ChatResponse, error) {
+//
+//nolint:gocritic // hugeParam: Chat takes the request by value so the SDK never mutates the caller's payload
+func (c Client) Chat(req ChatRequest, opts ...Option) (ChatResponse, error) {
 	return newChatService(c.opts).complete(req, opts...)
 }
 
@@ -55,8 +66,17 @@ func (c Client) Chat(req *ChatRequest, opts ...Option) (ChatResponse, error) {
 // Callers should Close the returned ChatStream when finished so the underlying HTTP
 // connection and decoder goroutine are released promptly.
 //
-// The caller must not mutate req while the request is being processed.
-// For safe concurrent usage, create a new ChatRequest for each concurrent call.
+// The request is passed by value and the SDK never mutates the received
+// payload. The value copy shares the request's nested data (slices, maps, and
+// pointed-to values) with the caller, so the caller must treat the request and
+// the data it references as read-only while a call is in flight.
+//
+// Concurrency:
+//   - A single Client is safe for concurrent use.
+//   - Reusing one request across sequential, fully-awaited calls is safe.
+//   - To invoke the same template request from multiple goroutines, pass a
+//     defensive copy per call, e.g. go client.ChatStream(req.Clone(), ...), or
+//     build a fresh request per call.
 //
 // Model Precedence:
 // The Model field is resolved with the following precedence (highest to lowest):
@@ -75,9 +95,11 @@ func (c Client) Chat(req *ChatRequest, opts ...Option) (ChatResponse, error) {
 //   - Model="mistral-7b:huggingface", Provider="" → "mistral-7b:huggingface"
 //
 // Behavior:
-//   - Returns a configuration error if req is nil.
+//   - Returns a configuration error if the request is missing a model or messages.
 //   - Always sends the request with streaming enabled.
-func (c Client) ChatStream(req *ChatRequest, opts ...Option) (*ChatStream, error) {
+//
+//nolint:gocritic // hugeParam: ChatStream takes the request by value so the SDK never mutates the caller's payload
+func (c Client) ChatStream(req ChatRequest, opts ...Option) (*ChatStream, error) {
 	return newChatService(c.opts).completeStream(req, opts...)
 }
 
@@ -87,7 +109,10 @@ func (c Client) ChatStream(req *ChatRequest, opts ...Option) (*ChatStream, error
 // For multiple classification inputs, use ClassifyTextBatch.
 //
 // The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (c Client) ClassifyText(req TextClassificationRequest, opts ...Option) ([]TextClassification, error) {
+func (c Client) ClassifyText(
+	req TextClassificationRequest,
+	opts ...Option,
+) ([]TextClassification, error) {
 	return newTextClassificationService(c.opts).classify(req, opts...)
 }
 
@@ -100,7 +125,10 @@ func (c Client) ClassifyText(req TextClassificationRequest, opts ...Option) ([]T
 // Callers should check the length of the response list before indexing.
 //
 // The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (c Client) ClassifyTextBatch(req TextClassificationBatchRequest, opts ...Option) ([][]TextClassification, error) {
+func (c Client) ClassifyTextBatch(
+	req TextClassificationBatchRequest,
+	opts ...Option,
+) ([][]TextClassification, error) {
 	return newTextClassificationService(c.opts).classifyBatch(req, opts...)
 }
 
@@ -110,7 +138,10 @@ func (c Client) ClassifyTextBatch(req TextClassificationBatchRequest, opts ...Op
 // For multiple inputs, use ZeroShotClassifyTextBatch.
 //
 // The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (c Client) ZeroShotClassifyText(req ZeroShotTextClassificationRequest, opts ...Option) ([]ZeroShotTextClassification, error) {
+func (c Client) ZeroShotClassifyText(
+	req ZeroShotTextClassificationRequest,
+	opts ...Option,
+) ([]ZeroShotTextClassification, error) {
 	return newZeroShotTextClassificationService(c.opts).classify(req, opts...)
 }
 
@@ -124,7 +155,10 @@ func (c Client) ZeroShotClassifyText(req ZeroShotTextClassificationRequest, opts
 // Callers should check the length of the response list before indexing.
 //
 // The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (c Client) ZeroShotClassifyTextBatch(req ZeroShotTextClassificationBatchRequest, opts ...Option) ([][]ZeroShotTextClassification, error) {
+func (c Client) ZeroShotClassifyTextBatch(
+	req ZeroShotTextClassificationBatchRequest,
+	opts ...Option,
+) ([][]ZeroShotTextClassification, error) {
 	return newZeroShotTextClassificationService(c.opts).classifyBatch(req, opts...)
 }
 
@@ -147,7 +181,10 @@ func (c Client) FillMask(req FillMaskRequest, opts ...Option) ([]FillMaskPredict
 // Callers should check the length of the response list before indexing.
 //
 // The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (c Client) FillMaskBatch(req FillMaskBatchRequest, opts ...Option) ([][]FillMaskPrediction, error) {
+func (c Client) FillMaskBatch(
+	req FillMaskBatchRequest,
+	opts ...Option,
+) ([][]FillMaskPrediction, error) {
 	return newFillMaskService(c.opts).fillBatch(req, opts...)
 }
 
@@ -174,7 +211,10 @@ func (c Client) Summarize(req SummarizationRequest, opts ...Option) ([]Summariza
 // how the API returns a list even for a single input.
 //
 // The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (c Client) SummarizeBatch(req SummarizationBatchRequest, opts ...Option) ([]Summarization, error) {
+func (c Client) SummarizeBatch(
+	req SummarizationBatchRequest,
+	opts ...Option,
+) ([]Summarization, error) {
 	return newSummarizationService(c.opts).summarizeBatch(req, opts...)
 }
 

--- a/client.go
+++ b/client.go
@@ -122,13 +122,31 @@ func (c Client) FillMaskBatch(req FillMaskBatchRequest, opts ...Option) ([][]Fil
 	return newFillMaskService(c.opts).fillBatch(req, opts...)
 }
 
-// Summarization returns a SummarizationService instance configured with this client's options.
-// The summarization service provides methods for interacting with summarization endpoints.
-// Service configurations are captured at creation time and do not change if the client options change later.
-// Clients are immutable to keep concurrency simple and request behavior predictable.
-// Services are lightweight; prefer to call Summarization() per use instead of retaining the value.
-func (c Client) Summarization() SummarizationService {
-	return newSummarizationService(c.opts)
+// Summarize sends a summarization request and returns the summarization output
+// for a single input.
+//
+// The API always returns a list for summarization; a single input yields a
+// one-element list rather than a bare summary object.
+//
+// For multiple inputs, use SummarizeBatch.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) Summarize(req SummarizationRequest, opts ...Option) ([]Summarization, error) {
+	return newSummarizationService(c.opts).summarize(req, opts...)
+}
+
+// SummarizeBatch sends a summarization request for a batch of inputs and returns
+// a flat list of summarization outputs, one for each input in the batch, in the
+// same order as the inputs.
+//
+// NOTE: Batched inference is supported by the upstream API, but is not
+// officially documented; behavior may change without notice. The response is
+// a flat list (one summary per input) — not a nested list — consistent with
+// how the API returns a list even for a single input.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) SummarizeBatch(req SummarizationBatchRequest, opts ...Option) ([]Summarization, error) {
+	return newSummarizationService(c.opts).summarizeBatch(req, opts...)
 }
 
 // Raw returns a RawService instance configured with this client's options.

--- a/clone.go
+++ b/clone.go
@@ -1,0 +1,35 @@
+package hfgo
+
+// clonePtr returns a copy of the pointee of ptr, or nil if ptr is nil.
+func clonePtr[T any](ptr *T) *T {
+	if ptr == nil {
+		return nil
+	}
+	value := *ptr
+
+	return &value
+}
+
+// cloneStructPtr returns a deep copy of the pointed-to struct, or nil if src is nil,
+// using clone to produce the copy.
+func cloneStructPtr[T any](src *T, clone func(*T) T) *T {
+	if src == nil {
+		return nil
+	}
+	dst := clone(src)
+
+	return &dst
+}
+
+// cloneSlice returns a deep copy of src, or nil if src is nil, using clone on each element.
+func cloneSlice[T any](src []T, clone func(*T) T) []T {
+	if src == nil {
+		return nil
+	}
+	dst := make([]T, len(src))
+	for idx := range src {
+		dst[idx] = clone(&src[idx])
+	}
+
+	return dst
+}

--- a/clone_test.go
+++ b/clone_test.go
@@ -3,7 +3,6 @@
 package hfgo
 
 import (
-	"encoding/json"
 	"net/http"
 	"sync"
 	"testing"
@@ -12,70 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestChatRequestClone_Deep(t *testing.T) {
-	t.Parallel()
-
-	schema := json.RawMessage(`{"type":"object"}`)
-	req := &ChatRequest{
-		Model: testutils.Ptr("m"),
-		Messages: []ChatMessage{
-			{Role: "user", Content: ChatMessageContent{Text: testutils.Ptr("hello")}},
-		},
-		Stop: []string{"x"},
-		Tools: []ChatTool{
-			{Type: "function", Function: ChatFunctionDefinition{Name: "f", Parameters: schema}},
-		},
-		ResponseFormat: &ChatResponseFormat{
-			Type:       ResponseFormatTypeJSONSchema,
-			JSONSchema: &ChatJSONSchemaConfig{Name: "n", Schema: schema},
-		},
-		ToolChoice: &ChatToolChoice{Mode: testutils.Ptr(ToolChoiceModeAuto)},
-	}
-
-	cloned := req.Clone()
-
-	*cloned.Messages[0].Content.Text = "changed"
-	cloned.Messages[0].Role = "assistant"
-	cloned.Stop[0] = "y"
-	cloned.Tools[0].Function.Parameters = json.RawMessage(`{"type":"object"}zzz`)
-	cloned.ResponseFormat.JSONSchema.Schema = json.RawMessage(`{"type":"object"}xxx`)
-	*cloned.ToolChoice.Mode = ToolChoiceModeNone
-
-	require.Equal(t, "hello", *req.Messages[0].Content.Text)
-	require.Equal(t, "user", req.Messages[0].Role)
-	require.Equal(t, []string{"x"}, req.Stop)
-	require.JSONEq(t, `{"type":"object"}`, string(req.Tools[0].Function.Parameters))
-	require.JSONEq(t, `{"type":"object"}`, string(req.ResponseFormat.JSONSchema.Schema))
-	require.Equal(t, ToolChoiceModeAuto, *req.ToolChoice.Mode)
-}
-
-func TestRequestClones_NestedIndependence(t *testing.T) {
-	t.Parallel()
-
-	origParams := SummarizationParameters{
-		CleanUpTokenizationSpaces: testutils.Ptr(false),
-		Truncation:                testutils.Ptr(SummarizationTruncationLongestFirst),
-		GenerateParameters:        map[string]any{"max_new_tokens": 5},
-	}
-	single := SummarizationRequest{Input: "a", Parameters: &origParams}
-	batch := SummarizationBatchRequest{Inputs: []string{"a", "b"}, Parameters: &origParams}
-
-	singleCloned := single.Clone()
-	batchCloned := batch.Clone()
-
-	*singleCloned.Parameters.Truncation = SummarizationTruncationOnlyFirst
-	singleCloned.Parameters.GenerateParameters["max_new_tokens"] = 99
-	*singleCloned.Parameters.CleanUpTokenizationSpaces = true
-	batchCloned.Inputs[0] = "zzz"
-	*batchCloned.Parameters.Truncation = SummarizationTruncationDoNotTruncate
-
-	require.Equal(t, SummarizationTruncationLongestFirst, *origParams.Truncation)
-	require.Equal(t, "a", single.Input)
-	require.Equal(t, []string{"a", "b"}, batch.Inputs)
-	require.False(t, *origParams.CleanUpTokenizationSpaces)
-	require.Equal(t, 5, origParams.GenerateParameters["max_new_tokens"])
-}
 
 func TestChatRequest_SequentialReuseDoesNotMutate(t *testing.T) {
 	t.Parallel()

--- a/clone_test.go
+++ b/clone_test.go
@@ -64,4 +64,9 @@ func TestChatRequestClone_ConcurrentInvocation(t *testing.T) {
 		})
 	}
 	wg.Wait()
+
+	require.NotNil(t, req.Messages)
+	require.NotNil(t, req.Messages[0].Content.Text)
+	require.Equal(t, "hi", *req.Messages[0].Content.Text)
+	require.Nil(t, req.Model)
 }

--- a/clone_test.go
+++ b/clone_test.go
@@ -1,0 +1,132 @@
+//go:build !integration
+
+package hfgo
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/Kardbord/hfgo/v4/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatRequestClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	schema := json.RawMessage(`{"type":"object"}`)
+	req := &ChatRequest{
+		Model: testutils.Ptr("m"),
+		Messages: []ChatMessage{
+			{Role: "user", Content: ChatMessageContent{Text: testutils.Ptr("hello")}},
+		},
+		Stop: []string{"x"},
+		Tools: []ChatTool{
+			{Type: "function", Function: ChatFunctionDefinition{Name: "f", Parameters: schema}},
+		},
+		ResponseFormat: &ChatResponseFormat{
+			Type:       ResponseFormatTypeJSONSchema,
+			JSONSchema: &ChatJSONSchemaConfig{Name: "n", Schema: schema},
+		},
+		ToolChoice: &ChatToolChoice{Mode: testutils.Ptr(ToolChoiceModeAuto)},
+	}
+
+	cloned := req.Clone()
+
+	*cloned.Messages[0].Content.Text = "changed"
+	cloned.Messages[0].Role = "assistant"
+	cloned.Stop[0] = "y"
+	cloned.Tools[0].Function.Parameters = json.RawMessage(`{"type":"object"}zzz`)
+	cloned.ResponseFormat.JSONSchema.Schema = json.RawMessage(`{"type":"object"}xxx`)
+	*cloned.ToolChoice.Mode = ToolChoiceModeNone
+
+	require.Equal(t, "hello", *req.Messages[0].Content.Text)
+	require.Equal(t, "user", req.Messages[0].Role)
+	require.Equal(t, []string{"x"}, req.Stop)
+	require.JSONEq(t, `{"type":"object"}`, string(req.Tools[0].Function.Parameters))
+	require.JSONEq(t, `{"type":"object"}`, string(req.ResponseFormat.JSONSchema.Schema))
+	require.Equal(t, ToolChoiceModeAuto, *req.ToolChoice.Mode)
+}
+
+func TestRequestClones_NestedIndependence(t *testing.T) {
+	t.Parallel()
+
+	origParams := SummarizationParameters{
+		CleanUpTokenizationSpaces: testutils.Ptr(false),
+		Truncation:                testutils.Ptr(SummarizationTruncationLongestFirst),
+		GenerateParameters:        map[string]any{"max_new_tokens": 5},
+	}
+	single := SummarizationRequest{Input: "a", Parameters: &origParams}
+	batch := SummarizationBatchRequest{Inputs: []string{"a", "b"}, Parameters: &origParams}
+
+	singleCloned := single.Clone()
+	batchCloned := batch.Clone()
+
+	*singleCloned.Parameters.Truncation = SummarizationTruncationOnlyFirst
+	singleCloned.Parameters.GenerateParameters["max_new_tokens"] = 99
+	*singleCloned.Parameters.CleanUpTokenizationSpaces = true
+	batchCloned.Inputs[0] = "zzz"
+	*batchCloned.Parameters.Truncation = SummarizationTruncationDoNotTruncate
+
+	require.Equal(t, SummarizationTruncationLongestFirst, *origParams.Truncation)
+	require.Equal(t, "a", single.Input)
+	require.Equal(t, []string{"a", "b"}, batch.Inputs)
+	require.False(t, *origParams.CleanUpTokenizationSpaces)
+	require.Equal(t, 5, origParams.GenerateParameters["max_new_tokens"])
+}
+
+func TestChatRequest_SequentialReuseDoesNotMutate(t *testing.T) {
+	t.Parallel()
+
+	text := "hi"
+	req := ChatRequest{
+		Messages: []ChatMessage{
+			{Role: "user", Content: ChatMessageContent{Text: &text}},
+		},
+	}
+
+	call := func() {
+		mt := testutils.NewJSONMockTransport(http.StatusOK, chatServiceResponseBody, nil)
+		client := NewClient(
+			WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+			WithModel("default-model"),
+		)
+		_, err := client.Chat(req)
+		require.NoError(t, err)
+		require.Nil(t, req.Model)
+	}
+
+	call()
+	req.Stop = []string{"x"}
+	call()
+}
+
+func TestChatRequestClone_ConcurrentInvocation(t *testing.T) {
+	t.Parallel()
+
+	text := "hi"
+	req := ChatRequest{
+		Messages: []ChatMessage{
+			{Role: "user", Content: ChatMessageContent{Text: &text}},
+		},
+	}
+
+	const workers = 16
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			mt := testutils.NewJSONMockTransport(http.StatusOK, chatServiceResponseBody, nil)
+			client := NewClient(
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
+				WithModel("default-model"),
+			)
+			_, err := client.Chat(req.Clone())
+			assert.NoError(t, err)
+		})
+	}
+	wg.Wait()
+}

--- a/doc.go
+++ b/doc.go
@@ -1,14 +1,14 @@
 // Package hfgo provides Go bindings for the Hugging Face Inference API.
 //
 // Design notes:
-//   - Clients are immutable; options are fixed at creation time, and services capture a snapshot.
-//   - Clients and services are safe for concurrent use by default or when configured with immutable or synchronized dependencies.
+//   - Clients are immutable; options are fixed at creation time, and each call snapshots them.
+//   - Clients are safe for concurrent use by default or when configured with immutable or synchronized dependencies.
 //   - Per-request options can override client defaults for a single call.
 //   - Request options are applied by value with defensive header copies; contexts and HTTP clients are shared.
 //   - HTTP client injection uses a value factory; return a fresh client value to avoid shared state.
 //   - The SDK favors upstream feature parity and uses DTOs closely aligned to the API; breaking changes are possible as the upstream API evolves.
 //   - WithDefaultHTTPClient restores the default client; a nil factory is treated as a configuration error.
-//   - RawService exposes both error-interpreting and raw request paths (Do vs DoRaw).
+//   - Client.Raw() returns the RawService escape hatch for arbitrary endpoints, exposing both error-interpreting and raw request paths (Do vs DoRaw).
 //   - DTO validation is enforced during JSON marshal/unmarshal. Invalid request
 //     payloads surface as configuration errors. For responses, invalid content
 //     type surfaces as validation errors, while malformed JSON surfaces as

--- a/doc.go
+++ b/doc.go
@@ -15,4 +15,8 @@
 //     serialization errors.
 //   - Concurrency assumes externally supplied objects (for example, transports) are not mutated after use
 //     unless callers provide their own synchronization.
+//   - Request DTOs are passed to Client methods by value and the SDK never mutates the caller's payload.
+//   - A request and the nested data it references must be treated as read-only while a call is in flight.
+//     For concurrent invocation, pass a defensive copy per call (for example, go client.Chat(req.Clone(), ...))
+//     or build a fresh request per call. Every request DTO provides a deep Clone method.
 package hfgo

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,15 +19,16 @@ The SDK follows a strict immutability pattern for concurrency safety:
 1. **Client**: Immutable value type that captures configuration at creation time
    - Options are fixed and never mutated
    - Safe for concurrent use across goroutines
-   - Services capture a snapshot of client options when created
-   - Lightweight; prefer calling `Chat()` or `Raw()` per use rather than caching service instances
+   - Each method call snapshots the client's options, so calls are independent and deterministic
 
-2. **Services**: Lightweight wrappers that snapshot client options
-   - `ChatService`: Chat completion endpoints (Complete, CompleteStream)
-   - `TextClassificationService`: Text classification endpoints (Classify, ClassifyBatch)
-   - `ZeroShotTextClassificationService`: Zero-shot text classification endpoints (Classify, ClassifyBatch)
-   - `SummarizationService`: Summarization endpoints (Summarize, SummarizeBatch)
-   - `RawService`: Raw HTTP request handling (Do, DoRaw, Stream, StreamReader)
+2. **Client Methods**: Every inference endpoint is called directly on the `Client`
+   - `Chat` / `ChatStream`: Chat completions
+   - `ClassifyText` / `ClassifyTextBatch`: Text classification
+   - `ZeroShotClassifyText` / `ZeroShotClassifyTextBatch`: Zero-shot text classification
+   - `FillMask` / `FillMaskBatch`: Mask filling
+   - `Summarize` / `SummarizeBatch`: Summarization
+   - The former per-domain service types are unexported implementation details; callers interact only with the Client
+   - `Client.Raw()` returns the `RawService` escape hatch for arbitrary endpoints (see below); it is the deliberate exception to the flat-method design
 
 3. **Per-Request Options**: Can override client defaults for single calls
    - Applied by value with defensive header copies
@@ -38,7 +39,7 @@ The SDK follows a strict immutability pattern for concurrency safety:
 From `doc.go` and README:
 
 - **Immutability**: Clients are immutable; to change options, create a new Client
-- **Concurrency**: Clients and services are safe for concurrent use by default
+- **Concurrency**: Clients are safe for concurrent use by default
 - **Feature Parity**: SDK favors upstream API feature parity; breaking changes possible as API evolves
 - **DTOs**: Request/response types closely aligned to the HuggingFace API
 - **Streaming**: Server-Sent Events (SSE) based streaming for chat completions
@@ -47,20 +48,18 @@ From `doc.go` and README:
 
 ### Concurrency Safety
 
-This SDK is **safe for concurrent use out of the box**. No explicit synchronization is required when using clients and services from multiple goroutines.
+This SDK is **safe for concurrent use out of the box**. No explicit synchronization is required when using a client from multiple goroutines.
 
 **Concurrency Guarantees**:
 - **Clients**: Fully concurrent-safe as immutable value types
-- **Services**: Concurrent-safe as lightweight snapshots of client options
-- **Per-request calls**: Each call is independent and concurrent-safe
+- **Client method calls**: Each call snapshots the client's options, so per-request overrides and concurrent calls never interfere
 - **Shared HTTP clients**: If you inject an HTTP client via `WithHTTPClientFactory()`, ensure it's either thread-safe by design or properly synchronized externally
 
 **How It Works**:
-The SDK achieves concurrency safety through immutability and snapshots:
+The SDK achieves concurrency safety through immutability:
 1. Clients never mutate their options after creation
-2. Services capture a snapshot of client options when created
-3. Per-request options are applied by value (defensive copies)
-4. No shared mutable state between goroutines
+2. Each method call derives a fresh snapshot from the client's options, applying per-request overrides by value (defensive copies)
+3. No shared mutable state between goroutines
 
 **Example**:
 ```go
@@ -69,12 +68,12 @@ client := NewClient(WithToken(token), WithModel("mistral-7b"))
 
 // Each goroutine can safely call methods
 go func() {
-    resp, err := client.Chat().Complete(req)
+    resp, err := client.Chat(req)
     // ...
 }()
 
 go func() {
-    stream, err := client.Chat().CompleteStream(req)
+    stream, err := client.ChatStream(req)
     // ...
 }()
 ```
@@ -138,7 +137,7 @@ All options are functions that return `hfgo.Option`. Applied to clients and per-
 When an option can be specified at multiple levels (client-level, request-level, or in request structures), the following precedence applies (highest to lowest):
 
 1. **Request Structure Fields** (if applicable): Values set directly in request structures (e.g., `ChatRequest.Model`)
-2. **Request-Level Options**: Options passed to individual method calls (e.g., `Complete(req, WithModel("..."))`)
+2. **Request-Level Options**: Options passed to individual method calls (e.g., `Chat(req, WithModel("..."))`)
 3. **Client-Level Options**: Options set when creating the Client (e.g., `NewClient(WithModel("..."))`)
 
 This precedence ensures that more specific (request-level) configurations always override more general (client-level) configurations.
@@ -149,14 +148,14 @@ This precedence ensures that more specific (request-level) configurations always
 client := NewClient(WithModel("default-model"))
 
 // Request-level override: "request-model"
-response, err := client.Chat().Complete(
+response, err := client.Chat(
     &ChatRequest{Messages: msgs},
     WithModel("request-model"),
 )
 // Result: Uses "request-model"
 
 // Request structure field: "structure-model"
-response, err := client.Chat().Complete(
+response, err := client.Chat(
     &ChatRequest{
         Model: ptr("structure-model"),
         Messages: msgs,
@@ -211,7 +210,7 @@ Represents a chat completion request. Key fields:
 - `PresencePenalty *float64`: Penalty for new topics (-2.0 to 2.0)
 - `Stop []string`: Stop sequences (up to 4)
 - `Seed *int64`: Deterministic sampling seed
-- `Stream *bool`: Enable streaming (use CompleteStream, not Complete)
+- `Stream *bool`: Enable streaming (use ChatStream, not Chat)
 - `StreamOptions *ChatStreamOptions`: SSE stream configuration
 - `Tools []ChatTool`: Available tools/functions
 - `ToolChoice *ChatToolChoice`: Tool selection behavior (auto, none, required, or function spec)
@@ -237,7 +236,7 @@ Validation:
 - Invalid response payloads surface as SDK validation errors
 
 ### ChatStream
-Wraps streaming chat completion response from `CompleteStream()`.
+Wraps streaming chat completion response from `ChatStream()`.
 
 **Methods**:
 - `Recv(ctx context.Context) (ChatStreamResponse, error)`: Blocks until next chunk arrives
@@ -283,19 +282,24 @@ Configuration for streaming responses.
 - `IncludeUsage *bool`: Include token usage in stream
 
 ### RawEvent
-Represents a raw SSE event from RawService streaming methods.
+Represents a raw SSE event from the raw streaming methods (`Client.Raw().Stream*`).
 
 - `Data []byte`: Event data payload
 - `Event string`: Event type identifier
 - `ID string`: Event ID
 - `Retry *time.Duration`: Retry duration hint (if provided)
 
-## Services
+## Client API
 
-### ChatService
-Created via `client.Chat()`. Methods:
+All inference endpoints are called directly on a `Client` value. Each method
+takes a request DTO and returns a typed response or stream; per-request options
+are passed as variadic `Option` values. The behavior below describes what the
+Client methods perform. The `RawService` exposed by `Client.Raw()` is the one
+exception and is documented separately.
 
-#### Complete(req *ChatRequest, opts ...Option) (ChatResponse, error)
+### Chat
+
+#### Chat(req *ChatRequest, opts ...Option) (ChatResponse, error)
 Non-streaming chat completion.
 
 **Model and Provider Precedence**:
@@ -309,50 +313,46 @@ The Provider field is applied as a fallback only if the resolved Model does not 
 **Behavior**:
 - Validates request is not nil
 - Applies per-request options to override client defaults
-- Rejects requests with Stream=true (use CompleteStream instead)
+- Rejects requests with Stream=true (use ChatStream instead)
 - Normalizes model and provider fields
 - Returns `ChatResponse` with all choices and usage stats
 - Returns `SDKError` (kind: Configuration) for invalid requests
 
-#### CompleteStream(req *ChatRequest, opts ...Option) (*ChatStream, error)
+#### ChatStream(req *ChatRequest, opts ...Option) (*ChatStream, error)
 Streaming chat completion using SSE.
 
 **Behavior**:
 - Validates request is not nil
 - Applies per-request options
-- Automatically sets Stream=true in request
+- Always sends the request with streaming enabled
 - Normalizes model and provider fields
 - Returns `*ChatStream` for consuming chunks
 - Caller must call `Close()` on returned stream
 - Returns `SDKError` (kind: Configuration) for invalid requests
 
-### TextClassificationService
-Created via `client.ClassifyText()`. For text classification tasks like sentiment analysis.
+### Text Classification
 
-#### Classify(req TextClassificationRequest, opts ...Option) ([]TextClassification, error)
+#### ClassifyText(req TextClassificationRequest, opts ...Option) ([]TextClassification, error)
 Single text classification.
 
 **Behavior**:
-- Validates request contains exactly one input
-- Returns error if multiple inputs provided (use ClassifyBatch instead)
 - Applies per-request options
 - Returns flat array of classifications for the single input
-- Automatically unwraps batch response to get single input result
+- Automatically unwraps the response to get the single input result
 
-#### ClassifyBatch(req TextClassificationRequest, opts ...Option) ([][]TextClassification, error)
+#### ClassifyTextBatch(req TextClassificationBatchRequest, opts ...Option) ([][]TextClassification, error)
 Batch text classification for multiple inputs.
 
 **API Response Format Normalization**:
-The service handles a quirk in the HuggingFace API where the response format differs based on whether the `TopK` parameter is explicitly set:
+The SDK handles a quirk in the HuggingFace API where the response format differs based on whether the `TopK` parameter is explicitly set:
 - **When TopK is explicitly set**: Returns `[[classifications for input1], [classifications for input2], ...]` (per-input format)
 - **When TopK is unset (nil)**: Returns `[[all classifications together]]` (flat format)
 
 This inconsistency is handled transparently by the `normalizeTextClassificationResponse()` helper function.
 
-### ZeroShotTextClassificationService
-Created via `client.ZeroShotClassifyText()`. For zero-shot text classification tasks.
+### Zero-Shot Text Classification
 
-#### Classify(req ZeroShotTextClassificationRequest, opts ...Option) ([]ZeroShotTextClassification, error)
+#### ZeroShotClassifyText(req ZeroShotTextClassificationRequest, opts ...Option) ([]ZeroShotTextClassification, error)
 Single input zero-shot text classification.
 
 **Behavior**:
@@ -361,54 +361,83 @@ Single input zero-shot text classification.
 - Applies per-request options
 - Returns flat array of classifications for the single input, ordered by score (descending)
 
-#### ClassifyBatch(req ZeroShotTextClassificationBatchRequest, opts ...Option) ([][]ZeroShotTextClassification, error)
+#### ZeroShotClassifyTextBatch(req ZeroShotTextClassificationBatchRequest, opts ...Option) ([][]ZeroShotTextClassification, error)
 Batch zero-shot text classification for multiple inputs.
 
 **API Response Normalization**:
-The HuggingFace API returns batched zero-shot results in a different format than single inputs. The service transparently normalizes responses via `normalizeZeroShotTextClassificationResponse()`.
+The HuggingFace API returns batched zero-shot results in a different format than single inputs. The SDK transparently normalizes responses via `normalizeZeroShotTextClassificationResponse()`.
 
-### SummarizationService
-Created via `client.Summarization()`. For text summarization tasks.
+### Fill Mask
+
+#### FillMask(req FillMaskRequest, opts ...Option) ([]FillMaskPrediction, error)
+Single input mask filling.
+
+**Behavior**:
+- Applies per-request options
+- Validates that a model is configured
+- Returns ranked mask filling predictions for the single input
+
+#### FillMaskBatch(req FillMaskBatchRequest, opts ...Option) ([][]FillMaskPrediction, error)
+Batch mask filling for multiple inputs.
+
+**Behavior**:
+- Applies per-request options
+- Validates that a model is configured
+- Returns a list of prediction lists, one per input, in input order
+- Callers should check the length of the response list before indexing
+
+### Summarization
 
 #### Summarize(req SummarizationRequest, opts ...Option) ([]Summarization, error)
 Single text summarization.
 
 **Behavior**:
-- Validates that a model is configured
-- Returns SDK error (kind: Configuration) if the model is missing
 - Applies per-request options
+- Validates that a model is configured
 - Returns a flat list of `Summarization` outputs for the single input
 
 #### SummarizeBatch(req SummarizationBatchRequest, opts ...Option) ([]Summarization, error)
 Batch text summarization for multiple inputs.
 
 **Behavior**:
-- Validates that a model is configured
-- Returns SDK error (kind: Configuration) if the model is missing
 - Applies per-request options
+- Validates that a model is configured
 - The API returns a flat list of `Summarization` outputs (one per input, in order) rather than a nested list, consistent with how it returns a list even for a single input
 
-### RawService
-Created via `client.Raw()`. For raw HTTP requests without type-safe JSON handling.
+### RawService (escape hatch)
 
-#### Do(body []byte, method, path string, opts ...Option) (*http.Response, error)
+Created via `client.Raw()`. For raw HTTP requests without type-safe JSON handling. This is the only endpoint path exposed as a service rather than as flat Client methods; it is the advanced escape hatch for endpoints the SDK does not model, and its broader method matrix is easier to discover grouped here.
+
+#### Do(requestBody []byte, method, path string, opts ...Option) (*http.Response, error)
 Raw request with error interpretation on non-2xx responses.
 
-#### DoRaw(body []byte, method, path string, opts ...Option) (*http.Response, error)
+#### DoRaw(requestBody []byte, method, path string, opts ...Option) (*http.Response, error)
 Raw request without error interpretation (allows non-2xx responses).
 
-#### Stream(body []byte, method, path string, opts ...Option) (*RawStream, error)
+#### DoReader(requestBody io.Reader, method, path string, opts ...Option) (*http.Response, error)
+Same as `Do`, but streams the request body from an `io.Reader`.
+
+#### DoRawReader(requestBody io.Reader, method, path string, opts ...Option) (*http.Response, error)
+Same as `DoRaw`, but streams the request body from an `io.Reader`.
+
+#### Stream(requestBody []byte, method, path string, opts ...Option) (*RawStream, error)
 SSE stream with error interpretation.
 
-#### StreamRaw(body []byte, method, path string, opts ...Option) (*RawStream, error)
+#### StreamReader(requestBody io.Reader, method, path string, opts ...Option) (*RawStream, error)
+Same as `Stream`, but streams the request body from an `io.Reader`.
+
+#### StreamRaw(requestBody []byte, method, path string, opts ...Option) (*RawStream, error)
 SSE stream without error interpretation (allows non-2xx responses).
+
+#### StreamRawReader(requestBody io.Reader, method, path string, opts ...Option) (*RawStream, error)
+Same as `StreamRaw`, but streams the request body from an `io.Reader`.
 
 ## Endpoints
 
 ### Chat Completions
 - **Constant**: `EndpointChatCompletion = "/v1/chat/completions"`
 - **Method**: POST
-- **Service**: `ChatService.Complete()` or `ChatService.CompleteStream()`
+- **Methods**: `Client.Chat(...)` or `Client.ChatStream(...)`
 
 ## Quality Assurance
 
@@ -458,7 +487,7 @@ go test -coverprofile=coverage.out -covermode=atomic ./...
 
 ### 1. Concurrency & Immutability
 - Create new Client for different configurations, don't mutate
-- Services are lightweight; create per use rather than caching
+- Client methods snapshot the client's options on each call, so nothing needs to be cached or pre-bound
 
 ### 2. Error Handling
 - Always type-assert errors to APIError or SDKError
@@ -466,7 +495,7 @@ go test -coverprofile=coverage.out -covermode=atomic ./...
 - Always close Body on APIError
 
 ### 3. Request Mutation Safety
-- Do not mutate ChatRequest after passing it to Complete or CompleteStream
+- Do not mutate ChatRequest after passing it to Chat or ChatStream
 - For concurrent requests, create a new ChatRequest for each call
 
 ### 4. Streaming

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,17 +63,18 @@ The SDK achieves concurrency safety through immutability:
 
 **Example**:
 ```go
-// Safe: Single client used by multiple goroutines
+// Safe: Single immutable client used by multiple goroutines
 client := NewClient(WithToken(token), WithModel("mistral-7b"))
 
-// Each goroutine can safely call methods
+// Each goroutine passes its OWN defensive copy of the request, so the shared
+// template is only ever read — never mutated while another call is in flight.
 go func() {
-    resp, err := client.Chat(req)
+    resp, err := client.Chat(req.Clone())
     // ...
 }()
 
 go func() {
-    stream, err := client.ChatStream(req)
+    stream, err := client.ChatStream(req.Clone())
     // ...
 }()
 ```
@@ -149,14 +150,14 @@ client := NewClient(WithModel("default-model"))
 
 // Request-level override: "request-model"
 response, err := client.Chat(
-    &ChatRequest{Messages: msgs},
+    ChatRequest{Messages: msgs},
     WithModel("request-model"),
 )
 // Result: Uses "request-model"
 
 // Request structure field: "structure-model"
 response, err := client.Chat(
-    &ChatRequest{
+    ChatRequest{
         Model: ptr("structure-model"),
         Messages: msgs,
     },
@@ -299,8 +300,14 @@ exception and is documented separately.
 
 ### Chat
 
-#### Chat(req *ChatRequest, opts ...Option) (ChatResponse, error)
+#### Chat(req ChatRequest, opts ...Option) (ChatResponse, error)
 Non-streaming chat completion.
+
+**Concurrency and request mutation**:
+- The request is passed **by value**; the SDK never mutates the caller's payload.
+- The value copy shares nested data (slices, maps, pointed-to values) with the caller, so the request and the data it references must be treated as **read-only while a call is in flight**.
+- Sequential, fully-awaited reuse of one request is safe and requires no cloning.
+- For concurrent invocation, pass a defensive copy per call: `go client.Chat(req.Clone(), ...)`, or build a fresh request per call.
 
 **Model and Provider Precedence**:
 The Model field is resolved with the following precedence (highest to lowest):
@@ -311,18 +318,23 @@ The Model field is resolved with the following precedence (highest to lowest):
 The Provider field is applied as a fallback only if the resolved Model does not already contain a provider (indicated by ":" in the model string). If the Model is in the format "model:provider", the Provider option is ignored.
 
 **Behavior**:
-- Validates request is not nil
+- Returns `SDKError` (kind: Configuration) if the request is missing a model or messages (zero-value request)
 - Applies per-request options to override client defaults
 - Rejects requests with Stream=true (use ChatStream instead)
 - Normalizes model and provider fields
 - Returns `ChatResponse` with all choices and usage stats
 - Returns `SDKError` (kind: Configuration) for invalid requests
 
-#### ChatStream(req *ChatRequest, opts ...Option) (*ChatStream, error)
+#### ChatStream(req ChatRequest, opts ...Option) (*ChatStream, error)
 Streaming chat completion using SSE.
 
+**Concurrency and request mutation**:
+- The request is passed **by value**; the SDK never mutates the caller's payload.
+- The request is fully consumed before the stream is returned, so the same sequential-reuse rules as `Chat` apply.
+- For concurrent invocation, pass a defensive copy per call: `go client.ChatStream(req.Clone(), ...)`, or build a fresh request per call.
+
 **Behavior**:
-- Validates request is not nil
+- Returns `SDKError` (kind: Configuration) if the request is missing a model or messages (zero-value request)
 - Applies per-request options
 - Always sends the request with streaming enabled
 - Normalizes model and provider fields
@@ -494,9 +506,29 @@ go test -coverprofile=coverage.out -covermode=atomic ./...
 - Use helper methods on APIError
 - Always close Body on APIError
 
-### 3. Request Mutation Safety
-- Do not mutate ChatRequest after passing it to Chat or ChatStream
-- For concurrent requests, create a new ChatRequest for each call
+### 3. Concurrency & Request Safety
+
+Request DTOs (e.g. `ChatRequest`) are passed to Client methods **by value**, and the SDK only ever mutates its own internal copy. This is the entire guarantee.
+
+**What the SDK guarantees**:
+- The SDK never mutates the request payload you pass in.
+- A single immutable Client is safe for concurrent use.
+
+**What the SDK does *not* guarantee, and why**:
+- Because the value copy shares the request's nested data by reference (slices, maps, and pointed-to values), the SDK cannot prevent a caller from racing against an in-flight call by mutating that nested data.
+- Go offers libraries no way to intercept ordinary field reads/writes on a plain struct, and retrofitting synchronization (mutexes, atomics, getters/setters) would make the DTOs non-copyable — destroying the value-copy semantics the whole SDK is built on. Preventing caller-authored races is therefore **structurally impossible** from inside the SDK; it is a caller responsibility.
+
+**Safe usage patterns**:
+1. **Read-only request**: Treat the request and the data it references as read-only while a call is in flight. Sequential, fully-awaited reuse is safe and needs no cloning.
+2. **Defensive copy for concurrency**: Invoke with a per-call deep copy so each goroutine owns its request:
+   ```go
+   go client.Chat(req.Clone(), ...)      // each goroutine passes its own copy
+   go client.ChatStream(req.Clone(), ...)
+   ```
+   `Clone()` is a **deep** copy: every slice gets new backing storage and every pointer a new pointee, so a clone shares nothing with its source. Exception: the value of an entry in `SummarizationParameters.GenerateParameters` (`map[string]any`) is shared, because its type is not known statically.
+3. **No reuse**: Simply build a fresh request per call or per goroutine and never share request objects.
+
+**Never**: share one mutable request object across goroutines and mutate it while calls are in flight — that is a data race the SDK cannot observe or prevent.
 
 ### 4. Streaming
 - Always call Close() on ChatStream or RawStream

--- a/examples/chat/basic/chat_basic.go
+++ b/examples/chat/basic/chat_basic.go
@@ -23,7 +23,7 @@ func main() {
 	)
 
 	// Create a chat request with a simple message
-	request := &hfgo.ChatRequest{
+	request := hfgo.ChatRequest{
 		Messages: []hfgo.ChatMessage{
 			{
 				Role: "user",

--- a/examples/chat/basic/chat_basic.go
+++ b/examples/chat/basic/chat_basic.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Kardbord/hfgo/v4"
 )
 
-// This example demonstrates how to use the ChatService for basic (non-streaming)
+// This example demonstrates how to use the client for basic (non-streaming)
 // chat completions. It sends a single message to the model and prints the response.
 func main() {
 	token := os.Getenv("HF_TOKEN")
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	// Send the request and get the response
-	response, err := client.Chat().Complete(request)
+	response, err := client.Chat(request)
 	if err != nil {
 		log.Fatalf("Failed to complete chat request: %v", err)
 	}

--- a/examples/chat/convo/convo.go
+++ b/examples/chat/convo/convo.go
@@ -60,7 +60,7 @@ func (chatClient *ChatClient) Chat() error {
 	fmt.Println("Welcome to this chat bot example! Press Ctrl+d at any time to exit.")
 	fmt.Println("Initializing...")
 	stream, err := chatClient.hfClient.ChatStream(
-		&hfgo.ChatRequest{
+		hfgo.ChatRequest{
 			Messages: chatClient.history, // Initialize with the system prompt given to NewChatClient
 		},
 	)
@@ -114,7 +114,7 @@ func (chatClient *ChatClient) prompt(input string) (*hfgo.ChatStream, error) {
 	})
 
 	return chatClient.hfClient.ChatStream(
-		&hfgo.ChatRequest{
+		hfgo.ChatRequest{
 			Messages: chatClient.history,
 		},
 		hfgo.WithContext(context.Background()),

--- a/examples/chat/convo/convo.go
+++ b/examples/chat/convo/convo.go
@@ -59,7 +59,7 @@ func NewChatClient(sysPrompt string) ChatClient {
 func (chatClient *ChatClient) Chat() error {
 	fmt.Println("Welcome to this chat bot example! Press Ctrl+d at any time to exit.")
 	fmt.Println("Initializing...")
-	stream, err := chatClient.hfClient.Chat().CompleteStream(
+	stream, err := chatClient.hfClient.ChatStream(
 		&hfgo.ChatRequest{
 			Messages: chatClient.history, // Initialize with the system prompt given to NewChatClient
 		},
@@ -113,7 +113,7 @@ func (chatClient *ChatClient) prompt(input string) (*hfgo.ChatStream, error) {
 		},
 	})
 
-	return chatClient.hfClient.Chat().CompleteStream(
+	return chatClient.hfClient.ChatStream(
 		&hfgo.ChatRequest{
 			Messages: chatClient.history,
 		},

--- a/examples/chat/streaming/chat_streaming.go
+++ b/examples/chat/streaming/chat_streaming.go
@@ -28,7 +28,7 @@ func main() {
 
 	// Create a chat request for streaming
 	prompt := "Tell me a short joke about programming."
-	request := &hfgo.ChatRequest{
+	request := hfgo.ChatRequest{
 		Messages: []hfgo.ChatMessage{
 			{
 				Role: "user",

--- a/examples/chat/streaming/chat_streaming.go
+++ b/examples/chat/streaming/chat_streaming.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Kardbord/hfgo/v4"
 )
 
-// This example demonstrates how to use the ChatService for streaming chat completions.
+// This example demonstrates how to use the client for streaming chat completions.
 // It sends a message to the model and processes the response stream in real-time.
 func main() {
 	// Get the API token from environment variable
@@ -47,7 +47,7 @@ func main() {
 	ctx := context.Background()
 
 	// Send the streaming request
-	stream, err := client.Chat().CompleteStream(request, hfgo.WithContext(ctx))
+	stream, err := client.ChatStream(request, hfgo.WithContext(ctx))
 	if err != nil {
 		log.Fatalf("Failed to start streaming chat request: %v", err)
 	}

--- a/examples/fill-mask/basic/fill_mask.go
+++ b/examples/fill-mask/basic/fill_mask.go
@@ -28,7 +28,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the fill mask request
-	predictions, err := client.FillMask().Fill(
+	predictions, err := client.FillMask(
 		hfgo.FillMaskRequest{
 			Input: input,
 		},

--- a/examples/fill-mask/batch/fill_mask_batch.go
+++ b/examples/fill-mask/batch/fill_mask_batch.go
@@ -32,7 +32,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the batched fill mask request
-	predictions, err := client.FillMask().FillBatch(
+	predictions, err := client.FillMaskBatch(
 		hfgo.FillMaskBatchRequest{
 			Inputs: inputs,
 		},

--- a/examples/fill-mask/params/fill_mask_params.go
+++ b/examples/fill-mask/params/fill_mask_params.go
@@ -36,7 +36,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the fill mask request with parameters
-	predictions, err := client.FillMask().Fill(
+	predictions, err := client.FillMask(
 		hfgo.FillMaskRequest{
 			Input: input,
 			Parameters: &hfgo.FillMaskParameters{

--- a/examples/summarization/basic/summarization.go
+++ b/examples/summarization/basic/summarization.go
@@ -30,7 +30,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the summarization request
-	summaries, err := client.Summarization().Summarize(
+	summaries, err := client.Summarize(
 		hfgo.SummarizationRequest{
 			Input: input,
 		},

--- a/examples/summarization/batch/summarization_batch.go
+++ b/examples/summarization/batch/summarization_batch.go
@@ -31,7 +31,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the batched summarization request
-	summaries, err := client.Summarization().SummarizeBatch(
+	summaries, err := client.SummarizeBatch(
 		hfgo.SummarizationBatchRequest{
 			Inputs: inputs,
 		},

--- a/examples/summarization/params/summarization_params.go
+++ b/examples/summarization/params/summarization_params.go
@@ -32,7 +32,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the summarization request with custom parameters
-	summaries, err := client.Summarization().Summarize(
+	summaries, err := client.Summarize(
 		hfgo.SummarizationRequest{
 			Input: input,
 			Parameters: &hfgo.SummarizationParameters{

--- a/examples/text-classification/basic/text_classification.go
+++ b/examples/text-classification/basic/text_classification.go
@@ -28,7 +28,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the classification request
-	classifications, err := client.ClassifyText().Classify(
+	classifications, err := client.ClassifyText(
 		hfgo.TextClassificationRequest{
 			Input: input,
 			Parameters: &hfgo.TextClassificationParameters{

--- a/examples/text-classification/batch/batched_text_classification.go
+++ b/examples/text-classification/batch/batched_text_classification.go
@@ -31,7 +31,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the classification request
-	classifications, err := client.ClassifyText().ClassifyBatch(
+	classifications, err := client.ClassifyTextBatch(
 		hfgo.TextClassificationBatchRequest{
 			Inputs: input,
 			Parameters: &hfgo.TextClassificationParameters{

--- a/examples/zero-shot-text-classification/basic/zero_shot_text_classification.go
+++ b/examples/zero-shot-text-classification/basic/zero_shot_text_classification.go
@@ -35,7 +35,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the classification request
-	classifications, err := client.ZeroShotClassifyText().Classify(
+	classifications, err := client.ZeroShotClassifyText(
 		hfgo.ZeroShotTextClassificationRequest{
 			Input: input,
 			Parameters: &hfgo.ZeroShotTextClassificationParameters{

--- a/examples/zero-shot-text-classification/batch/batched_zero_shot_text_classification.go
+++ b/examples/zero-shot-text-classification/batch/batched_zero_shot_text_classification.go
@@ -38,7 +38,7 @@ func main() {
 	fmt.Println("...")
 
 	// Make the classification request
-	classifications, err := client.ZeroShotClassifyText().ClassifyBatch(
+	classifications, err := client.ZeroShotClassifyTextBatch(
 		hfgo.ZeroShotTextClassificationBatchRequest{
 			Inputs: inputs,
 			Parameters: &hfgo.ZeroShotTextClassificationParameters{

--- a/fill_mask.go
+++ b/fill_mask.go
@@ -1,5 +1,7 @@
 package hfgo
 
+import "slices"
+
 // FillMaskRequest represents a fill mask
 // inference request to the API for a single
 // input.
@@ -52,4 +54,39 @@ type FillMaskPrediction struct {
 
 	// The predicted token (to replace the masked one).
 	TokenStr *string `json:"token_str"`
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *FillMaskRequest) Clone() FillMaskRequest {
+	if r == nil {
+		return FillMaskRequest{}
+	}
+	out := *r
+	out.Parameters = cloneStructPtr(r.Parameters, (*FillMaskParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *FillMaskBatchRequest) Clone() FillMaskBatchRequest {
+	if r == nil {
+		return FillMaskBatchRequest{}
+	}
+	out := *r
+	out.Inputs = slices.Clone(r.Inputs)
+	out.Parameters = cloneStructPtr(r.Parameters, (*FillMaskParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the parameters.
+func (p *FillMaskParameters) Clone() FillMaskParameters {
+	if p == nil {
+		return FillMaskParameters{}
+	}
+	out := *p
+	out.Targets = slices.Clone(p.Targets)
+	out.TopK = clonePtr(p.TopK)
+
+	return out
 }

--- a/fill_mask_integration_test.go
+++ b/fill_mask_integration_test.go
@@ -28,7 +28,7 @@ func TestFillMask_LiveAPI(t *testing.T) {
 		WithContext(ctx),
 	)
 
-	resp, err := client.FillMask().Fill(
+	resp, err := client.FillMask(
 		FillMaskRequest{
 			Input: "The capital of France is [MASK].",
 		},
@@ -66,7 +66,7 @@ func TestFillMask_WithTopK(t *testing.T) {
 	)
 
 	topK := 3
-	resp, err := client.FillMask().Fill(
+	resp, err := client.FillMask(
 		FillMaskRequest{
 			Input: "The capital of France is [MASK].",
 			Parameters: &FillMaskParameters{
@@ -108,7 +108,7 @@ func TestFillMask_WithTargets(t *testing.T) {
 	)
 
 	targets := []string{"paris", "london"}
-	resp, err := client.FillMask().Fill(
+	resp, err := client.FillMask(
 		FillMaskRequest{
 			Input: "The capital of France is [MASK].",
 			Parameters: &FillMaskParameters{
@@ -150,7 +150,7 @@ func TestFillMask_BatchLiveAPI(t *testing.T) {
 		"The meeting was [MASK] due to the storm.",
 	}
 
-	resp, err := client.FillMask().FillBatch(
+	resp, err := client.FillMaskBatch(
 		FillMaskBatchRequest{
 			Inputs: inputs,
 		},
@@ -189,7 +189,7 @@ func TestFillMask_ContextCancellation(t *testing.T) {
 		WithContext(ctx),
 	)
 
-	resp, err := client.FillMask().Fill(
+	resp, err := client.FillMask(
 		FillMaskRequest{
 			Input: "The capital of France is [MASK].",
 		},
@@ -234,7 +234,7 @@ func TestFillMask_VeryLargeBatch(t *testing.T) {
 		inputs[i] = text
 	}
 
-	resp, err := client.FillMask().FillBatch(
+	resp, err := client.FillMaskBatch(
 		FillMaskBatchRequest{
 			Inputs: inputs,
 		},

--- a/fill_mask_service.go
+++ b/fill_mask_service.go
@@ -4,23 +4,18 @@ import (
 	"github.com/Kardbord/hfgo/v4/internal/request"
 )
 
-// FillMaskService implements fill mask calls using the configured request options.
-type FillMaskService struct {
+// fillMaskService implements fill mask calls using the configured request options.
+type fillMaskService struct {
 	opts request.Options
 }
 
-// newFillMaskService builds a FillMaskService with a snapshot of the provided options.
-func newFillMaskService(opts request.Options) FillMaskService {
-	return FillMaskService{opts: opts}
+// newFillMaskService builds a fill mask service with a snapshot of the provided options.
+func newFillMaskService(opts request.Options) fillMaskService {
+	return fillMaskService{opts: opts}
 }
 
-// Fill sends a fill mask request and returns the mask filling
-// predictions for a single input.
-//
-// For multiple inputs, use FillBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (s FillMaskService) Fill(
+// fill sends a fill mask request for a single input and returns the predictions.
+func (s fillMaskService) fill(
 	req FillMaskRequest,
 	opts ...Option,
 ) ([]FillMaskPrediction, error) {
@@ -31,17 +26,8 @@ func (s FillMaskService) Fill(
 	)
 }
 
-// FillBatch sends a fill mask request for a batch of inputs
-// and returns a list of mask filling predictions for each input in
-// the batch.
-//
-// NOTE: Batched inference is supported by the upstream API, but is not
-// officially documented; behavior may change without notice.
-//
-// Callers should check the length of the response list before indexing.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (s FillMaskService) FillBatch(
+// fillBatch sends a fill mask request for a batch of inputs and returns predictions per input.
+func (s fillMaskService) fillBatch(
 	req FillMaskBatchRequest,
 	opts ...Option,
 ) ([][]FillMaskPrediction, error) {

--- a/fill_mask_service_test.go
+++ b/fill_mask_service_test.go
@@ -69,7 +69,9 @@ func TestFillMaskService_FillMask_ResponseDecoding(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(tc.statusCode, tc.responseBody, nil)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel("test-model"),
 			)
 
@@ -257,7 +259,9 @@ func TestFillMaskService_FillMaskBatch_ResponseDecoding(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel("test-model"),
 			)
 

--- a/fill_mask_service_test.go
+++ b/fill_mask_service_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
-	"github.com/Kardbord/hfgo/v4/internal/request"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -69,16 +68,16 @@ func TestFillMaskService_FillMask_ResponseDecoding(t *testing.T) {
 		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(tc.statusCode, tc.responseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel("test-model")
-			svc := newFillMaskService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel("test-model"),
+			)
 
 			req := FillMaskRequest{
 				Input: "The capital of France is [MASK].",
 			}
 
-			result, err := svc.fill(req)
+			result, err := client.FillMask(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result)
 			require.Len(t, result, tc.expectedLen, tc.description)
@@ -109,10 +108,10 @@ func TestFillMaskService_FillMask_WithParameters(t *testing.T) {
 		`[{"sequence":"The quick brown fox jumps over the lazy dog.","score":0.95,"token":1,"token_str":"lazy"}]`,
 		nil,
 	)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-		WithModel("test-model")
-	svc := newFillMaskService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+		WithModel("test-model"),
+	)
 
 	topK := 5
 	req := FillMaskRequest{
@@ -123,7 +122,7 @@ func TestFillMaskService_FillMask_WithParameters(t *testing.T) {
 		},
 	}
 
-	result, err := svc.fill(req)
+	result, err := client.FillMask(req)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -171,8 +170,8 @@ func TestFillMaskService_FillMask_Errors(t *testing.T) {
 				description:  "API error for model not yet loaded",
 			},
 		},
-		func(opts request.Options) ([]FillMaskPrediction, error) {
-			return newFillMaskService(opts).fill(FillMaskRequest{
+		func(opts ...Option) ([]FillMaskPrediction, error) {
+			return NewClient(opts...).FillMask(FillMaskRequest{
 				Input: "The capital of France is [MASK].",
 			})
 		},
@@ -257,16 +256,16 @@ func TestFillMaskService_FillMaskBatch_ResponseDecoding(t *testing.T) {
 		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel("test-model")
-			svc := newFillMaskService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel("test-model"),
+			)
 
 			req := FillMaskBatchRequest{
 				Inputs: tc.inputs,
 			}
 
-			result, err := svc.fillBatch(req)
+			result, err := client.FillMaskBatch(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result)
 			require.Len(t, result, tc.expectedOuterLen, tc.description)
@@ -312,8 +311,8 @@ func TestFillMaskService_FillMaskBatch_Errors(t *testing.T) {
 				description:  "API error for model not yet loaded",
 			},
 		},
-		func(opts request.Options) ([][]FillMaskPrediction, error) {
-			return newFillMaskService(opts).fillBatch(FillMaskBatchRequest{
+		func(opts ...Option) ([][]FillMaskPrediction, error) {
+			return NewClient(opts...).FillMaskBatch(FillMaskBatchRequest{
 				Inputs: []string{"I [MASK] my dog everyday."},
 			})
 		},
@@ -328,15 +327,15 @@ func TestFillMaskService_FillMaskBatch_ModelFromOptions(t *testing.T) {
 		`[[{"sequence":"I walk my dog everyday.","score":0.95,"token":1,"token_str":"walk"}]]`,
 		nil,
 	)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newFillMaskService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
 	req := FillMaskBatchRequest{
 		Inputs: []string{"I [MASK] my dog everyday."},
 	}
 
-	result, err := svc.fillBatch(req, WithModel("override-model"))
+	result, err := client.FillMaskBatch(req, WithModel("override-model"))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/fill_mask_service_test.go
+++ b/fill_mask_service_test.go
@@ -78,7 +78,7 @@ func TestFillMaskService_FillMask_ResponseDecoding(t *testing.T) {
 				Input: "The capital of France is [MASK].",
 			}
 
-			result, err := svc.Fill(req)
+			result, err := svc.fill(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result)
 			require.Len(t, result, tc.expectedLen, tc.description)
@@ -123,7 +123,7 @@ func TestFillMaskService_FillMask_WithParameters(t *testing.T) {
 		},
 	}
 
-	result, err := svc.Fill(req)
+	result, err := svc.fill(req)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -172,7 +172,7 @@ func TestFillMaskService_FillMask_Errors(t *testing.T) {
 			},
 		},
 		func(opts request.Options) ([]FillMaskPrediction, error) {
-			return newFillMaskService(opts).Fill(FillMaskRequest{
+			return newFillMaskService(opts).fill(FillMaskRequest{
 				Input: "The capital of France is [MASK].",
 			})
 		},
@@ -266,7 +266,7 @@ func TestFillMaskService_FillMaskBatch_ResponseDecoding(t *testing.T) {
 				Inputs: tc.inputs,
 			}
 
-			result, err := svc.FillBatch(req)
+			result, err := svc.fillBatch(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result)
 			require.Len(t, result, tc.expectedOuterLen, tc.description)
@@ -313,7 +313,7 @@ func TestFillMaskService_FillMaskBatch_Errors(t *testing.T) {
 			},
 		},
 		func(opts request.Options) ([][]FillMaskPrediction, error) {
-			return newFillMaskService(opts).FillBatch(FillMaskBatchRequest{
+			return newFillMaskService(opts).fillBatch(FillMaskBatchRequest{
 				Inputs: []string{"I [MASK] my dog everyday."},
 			})
 		},
@@ -336,7 +336,7 @@ func TestFillMaskService_FillMaskBatch_ModelFromOptions(t *testing.T) {
 		Inputs: []string{"I [MASK] my dog everyday."},
 	}
 
-	result, err := svc.FillBatch(req, WithModel("override-model"))
+	result, err := svc.fillBatch(req, WithModel("override-model"))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/fill_mask_test.go
+++ b/fill_mask_test.go
@@ -1,0 +1,87 @@
+//go:build !integration
+
+package hfgo
+
+import (
+	"testing"
+
+	"github.com/Kardbord/hfgo/v4/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFillMaskRequestClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	req := FillMaskRequest{
+		Input: "The capital of France is [MASK].",
+		Parameters: &FillMaskParameters{
+			TopK:    testutils.Ptr(3),
+			Targets: []string{"Paris", "Lyon"},
+		},
+	}
+
+	cloned := req.Clone()
+
+	*cloned.Parameters.TopK = 5
+	cloned.Parameters.Targets[0] = "Marseille"
+	cloned.Input = "changed"
+
+	require.Equal(t, "The capital of France is [MASK].", req.Input)
+	require.Equal(t, 3, *req.Parameters.TopK)
+	require.Equal(t, []string{"Paris", "Lyon"}, req.Parameters.Targets)
+	require.Equal(t, 5, *cloned.Parameters.TopK)
+	require.Equal(t, "Marseille", cloned.Parameters.Targets[0])
+}
+
+func TestFillMaskBatchRequestClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	req := FillMaskBatchRequest{
+		Inputs: []string{"I [MASK] my dog.", "She is [MASK]."},
+		Parameters: &FillMaskParameters{
+			TopK: testutils.Ptr(2),
+		},
+	}
+
+	cloned := req.Clone()
+
+	cloned.Inputs[0] = "changed"
+	*cloned.Parameters.TopK = 4
+
+	require.Equal(t, []string{"I [MASK] my dog.", "She is [MASK]."}, req.Inputs)
+	require.Equal(t, 2, *req.Parameters.TopK)
+	require.Equal(t, "changed", cloned.Inputs[0])
+	require.Equal(t, 4, *cloned.Parameters.TopK)
+}
+
+func TestFillMaskParametersClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	params := &FillMaskParameters{
+		TopK:    testutils.Ptr(3),
+		Targets: []string{"Paris", "Lyon"},
+	}
+
+	cloned := params.Clone()
+
+	*cloned.TopK = 7
+	cloned.Targets[0] = "Marseille"
+
+	require.Equal(t, 3, *params.TopK)
+	require.Equal(t, []string{"Paris", "Lyon"}, params.Targets)
+	require.Equal(t, 7, *cloned.TopK)
+	require.Equal(t, "Marseille", cloned.Targets[0])
+}
+
+func TestFillMaskClone_Nil(t *testing.T) {
+	t.Parallel()
+
+	var r *FillMaskRequest
+	require.Empty(t, r.Clone())
+
+	var b *FillMaskBatchRequest
+	require.Empty(t, b.Clone())
+
+	var p *FillMaskParameters
+	require.Empty(t, p.Clone())
+}

--- a/raw_service.go
+++ b/raw_service.go
@@ -11,6 +11,15 @@ import (
 )
 
 // RawService sends raw HTTP requests using the configured request options.
+//
+// It is the deliberate exception to the rest of the SDK, where endpoints are
+// exposed as Client methods: RawService is the advanced escape hatch for
+// endpoints the SDK does not model type-safely. It combines several axes
+// (byte-slice or io.Reader bodies, typed error handling or raw HTTP responses,
+// one-shot or SSE streaming) into eight methods, which is enough surface that
+// keeping it namespaced under Client.Raw() avoids cluttering the Client API.
+//
+// RawService is immutable and holds a snapshot of the client options.
 type RawService struct {
 	opts request.Options
 }

--- a/raw_service_test.go
+++ b/raw_service_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Kardbord/hfgo/v4/internal/request"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
 )
 
@@ -20,11 +19,11 @@ func TestRawService_Stream_Success(t *testing.T) {
 	mt := testutils.NewMockTransport(http.StatusOK, body, nil)
 	mt.Response.Header.Set("Content-Type", "text/event-stream")
 
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newRawService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
-	stream, err := svc.Stream(nil, http.MethodGet, "/stream")
+	stream, err := client.Raw().Stream(nil, http.MethodGet, "/stream")
 	if err != nil {
 		t.Fatalf("Stream: %v", err)
 	}
@@ -50,11 +49,11 @@ func TestRawService_Stream_DoError(t *testing.T) {
 	t.Parallel()
 
 	mt := &testutils.MockTransport{Err: errors.New("boom")}
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newRawService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
-	_, err := svc.Stream(nil, http.MethodGet, "/stream")
+	_, err := client.Raw().Stream(nil, http.MethodGet, "/stream")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -67,11 +66,11 @@ func TestRawService_StreamRaw_AllowsNon2xx(t *testing.T) {
 	mt := testutils.NewMockTransport(http.StatusUnauthorized, body, nil)
 	mt.Response.Header.Set("Content-Type", "text/event-stream")
 
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newRawService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
-	stream, err := svc.StreamRaw(nil, http.MethodGet, "/stream")
+	stream, err := client.Raw().StreamRaw(nil, http.MethodGet, "/stream")
 	if err != nil {
 		t.Fatalf("StreamRaw: %v", err)
 	}

--- a/service_errors_test.go
+++ b/service_errors_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
-	"github.com/Kardbord/hfgo/v4/internal/request"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +42,7 @@ type errorCase struct {
 func runErrorCases[Res any](
 	t *testing.T,
 	cases []errorCase,
-	run func(opts request.Options) (Res, error),
+	run func(opts ...Option) (Res, error),
 ) {
 	t.Helper()
 
@@ -51,14 +50,16 @@ func runErrorCases[Res any](
 		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(tc.statusCode, tc.responseBody, nil)
-			opts := request.NewOptions().WithHTTPClientFactory(func() http.Client {
-				return testutils.NewMockHTTPClient(mt)
-			})
+			opts := []Option{
+				WithHTTPClientFactory(func() http.Client {
+					return testutils.NewMockHTTPClient(mt)
+				}),
+			}
 			if tc.withModel {
-				opts = opts.WithModel("nonexistent-model")
+				opts = append(opts, WithModel("nonexistent-model"))
 			}
 
-			result, err := run(opts)
+			result, err := run(opts...)
 			if err == nil {
 				t.Fatalf("expected an error: %s", tc.description)
 			}

--- a/summarization.go
+++ b/summarization.go
@@ -1,5 +1,10 @@
 package hfgo
 
+import (
+	"maps"
+	"slices"
+)
+
 // SummarizationRequest represents a summarization
 // inference request to the API for a single input.
 type SummarizationRequest struct {
@@ -59,4 +64,42 @@ const (
 type Summarization struct {
 	// The summarized text.
 	SummaryText string `json:"summary_text"`
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *SummarizationRequest) Clone() SummarizationRequest {
+	if r == nil {
+		return SummarizationRequest{}
+	}
+	out := *r
+	out.Parameters = cloneStructPtr(r.Parameters, (*SummarizationParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *SummarizationBatchRequest) Clone() SummarizationBatchRequest {
+	if r == nil {
+		return SummarizationBatchRequest{}
+	}
+	out := *r
+	out.Inputs = slices.Clone(r.Inputs)
+	out.Parameters = cloneStructPtr(r.Parameters, (*SummarizationParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the parameters. The GenerateParameters
+// map is copied as a new map, but its values are shared because their types are
+// not known statically.
+func (p *SummarizationParameters) Clone() SummarizationParameters {
+	if p == nil {
+		return SummarizationParameters{}
+	}
+	out := *p
+	out.CleanUpTokenizationSpaces = clonePtr(p.CleanUpTokenizationSpaces)
+	out.Truncation = clonePtr(p.Truncation)
+	out.GenerateParameters = maps.Clone(p.GenerateParameters)
+
+	return out
 }

--- a/summarization_integration_test.go
+++ b/summarization_integration_test.go
@@ -32,7 +32,7 @@ func TestSummarization_LiveAPI(t *testing.T) {
 		"Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel " +
 		"Tower surpassed the Washington Monument to become the tallest man-made structure in the world."
 
-	resp, err := client.Summarization().Summarize(
+	resp, err := client.Summarize(
 		SummarizationRequest{
 			Input: input,
 		},
@@ -66,7 +66,7 @@ func TestSummarization_BatchLiveAPI(t *testing.T) {
 		"The Moon orbits the Earth roughly every 27 days, a period known as a sidereal month.",
 	}
 
-	resp, err := client.Summarization().SummarizeBatch(
+	resp, err := client.SummarizeBatch(
 		SummarizationBatchRequest{
 			Inputs: inputs,
 		},
@@ -103,7 +103,7 @@ func TestSummarization_WithParameters(t *testing.T) {
 	truncation := SummarizationTruncationOnlyFirst
 	input := "The industrial revolution transformed agriculture, manufacturing, mining, and transport, " +
 		"leading to massive social and economic changes across the world."
-	resp, err := client.Summarization().Summarize(
+	resp, err := client.Summarize(
 		SummarizationRequest{
 			Input: input,
 			Parameters: &SummarizationParameters{
@@ -135,7 +135,7 @@ func TestSummarization_ContextCancellation(t *testing.T) {
 		WithContext(ctx),
 	)
 
-	resp, err := client.Summarization().Summarize(
+	resp, err := client.Summarize(
 		SummarizationRequest{
 			Input: "Some text that should be summarized.",
 		},

--- a/summarization_service.go
+++ b/summarization_service.go
@@ -4,28 +4,18 @@ import (
 	"github.com/Kardbord/hfgo/v4/internal/request"
 )
 
-// SummarizationService implements summarization calls
-// using the configured request options.
-type SummarizationService struct {
+// summarizationService implements summarization calls using the configured request options.
+type summarizationService struct {
 	opts request.Options
 }
 
-// newSummarizationService builds a SummarizationService with a snapshot
-// of the provided options.
-func newSummarizationService(opts request.Options) SummarizationService {
-	return SummarizationService{opts: opts}
+// newSummarizationService builds a summarization service with a snapshot of the provided options.
+func newSummarizationService(opts request.Options) summarizationService {
+	return summarizationService{opts: opts}
 }
 
-// Summarize sends a summarization request and returns the
-// summarization output for a single input.
-//
-// The API always returns a list for summarization; a single input yields a
-// one-element list rather than a bare summary object.
-//
-// For multiple inputs, use SummarizeBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (s SummarizationService) Summarize(
+// summarize sends a summarization request for a single input and returns the output.
+func (s summarizationService) summarize(
 	req SummarizationRequest,
 	opts ...Option,
 ) ([]Summarization, error) {
@@ -36,17 +26,8 @@ func (s SummarizationService) Summarize(
 	)
 }
 
-// SummarizeBatch sends a summarization request for a batch of inputs
-// and returns a flat list of summarization outputs, one for each input in
-// the batch, in the same order as the inputs.
-//
-// NOTE: Batched inference is supported by the upstream API, but is not
-// officially documented; behavior may change without notice. The response is
-// a flat list (one summary per input) — not a nested list — consistent with
-// how the API returns a list even for a single input.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (s SummarizationService) SummarizeBatch(
+// summarizeBatch sends a summarization request for a batch of inputs and returns a flat list of outputs.
+func (s summarizationService) summarizeBatch(
 	req SummarizationBatchRequest,
 	opts ...Option,
 ) ([]Summarization, error) {

--- a/summarization_service_test.go
+++ b/summarization_service_test.go
@@ -48,7 +48,9 @@ func TestSummarizationService_Summarize_ResponseVariations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel("test-model"),
 			)
 
@@ -143,7 +145,9 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 				nil,
 			)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel("test-model"),
 			)
 
@@ -237,7 +241,9 @@ func TestSummarizationService_SummarizeBatch_ResponseVariations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel("test-model"),
 			)
 

--- a/summarization_service_test.go
+++ b/summarization_service_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
-	"github.com/Kardbord/hfgo/v4/internal/request"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -48,12 +47,12 @@ func TestSummarizationService_Summarize_ResponseVariations(t *testing.T) {
 		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel("test-model")
-			svc := newSummarizationService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel("test-model"),
+			)
 
-			result, err := svc.summarize(SummarizationRequest{Input: "Some long text."})
+			result, err := client.Summarize(SummarizationRequest{Input: "Some long text."})
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result, tc.description)
 			require.Len(t, result, tc.wantLen, tc.description)
@@ -143,10 +142,10 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 				`[{"summary_text":"A concise summary."}]`,
 				nil,
 			)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel("test-model")
-			svc := newSummarizationService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel("test-model"),
+			)
 
 			req := SummarizationRequest{Input: "Some long text."}
 			if tc.cleanUp != nil || tc.truncation != nil || tc.generate != nil {
@@ -157,7 +156,7 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 				}
 			}
 
-			result, err := svc.summarize(req)
+			result, err := client.Summarize(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result, tc.description)
 
@@ -196,8 +195,8 @@ func TestSummarizationService_Summarize_Errors(t *testing.T) {
 				description:  "API error for nonexistent model",
 			},
 		},
-		func(opts request.Options) ([]Summarization, error) {
-			return newSummarizationService(opts).summarize(SummarizationRequest{
+		func(opts ...Option) ([]Summarization, error) {
+			return NewClient(opts...).Summarize(SummarizationRequest{
 				Input: "Some long text that should be summarized.",
 			})
 		},
@@ -237,12 +236,12 @@ func TestSummarizationService_SummarizeBatch_ResponseVariations(t *testing.T) {
 		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel("test-model")
-			svc := newSummarizationService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel("test-model"),
+			)
 
-			result, err := svc.summarizeBatch(SummarizationBatchRequest{
+			result, err := client.SummarizeBatch(SummarizationBatchRequest{
 				Inputs: []string{"Long text one.", "Long text two."},
 			})
 			require.NoError(t, err, tc.description)
@@ -278,8 +277,8 @@ func TestSummarizationService_SummarizeBatch_Errors(t *testing.T) {
 				description:  "API error for nonexistent model",
 			},
 		},
-		func(opts request.Options) ([]Summarization, error) {
-			return newSummarizationService(opts).summarizeBatch(SummarizationBatchRequest{
+		func(opts ...Option) ([]Summarization, error) {
+			return NewClient(opts...).SummarizeBatch(SummarizationBatchRequest{
 				Inputs: []string{"Long text one."},
 			})
 		},
@@ -294,11 +293,11 @@ func TestSummarizationService_SummarizeBatch_ModelFromOptions(t *testing.T) {
 		`[{"summary_text":"Summary one."}]`,
 		nil,
 	)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newSummarizationService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
-	result, err := svc.summarizeBatch(SummarizationBatchRequest{
+	result, err := client.SummarizeBatch(SummarizationBatchRequest{
 		Inputs: []string{"Long text one."},
 	}, WithModel("override-model"))
 	require.NoError(t, err)

--- a/summarization_service_test.go
+++ b/summarization_service_test.go
@@ -53,7 +53,7 @@ func TestSummarizationService_Summarize_ResponseVariations(t *testing.T) {
 				WithModel("test-model")
 			svc := newSummarizationService(opts)
 
-			result, err := svc.Summarize(SummarizationRequest{Input: "Some long text."})
+			result, err := svc.summarize(SummarizationRequest{Input: "Some long text."})
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result, tc.description)
 			require.Len(t, result, tc.wantLen, tc.description)
@@ -157,7 +157,7 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 				}
 			}
 
-			result, err := svc.Summarize(req)
+			result, err := svc.summarize(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result, tc.description)
 
@@ -197,7 +197,7 @@ func TestSummarizationService_Summarize_Errors(t *testing.T) {
 			},
 		},
 		func(opts request.Options) ([]Summarization, error) {
-			return newSummarizationService(opts).Summarize(SummarizationRequest{
+			return newSummarizationService(opts).summarize(SummarizationRequest{
 				Input: "Some long text that should be summarized.",
 			})
 		},
@@ -242,7 +242,7 @@ func TestSummarizationService_SummarizeBatch_ResponseVariations(t *testing.T) {
 				WithModel("test-model")
 			svc := newSummarizationService(opts)
 
-			result, err := svc.SummarizeBatch(SummarizationBatchRequest{
+			result, err := svc.summarizeBatch(SummarizationBatchRequest{
 				Inputs: []string{"Long text one.", "Long text two."},
 			})
 			require.NoError(t, err, tc.description)
@@ -279,7 +279,7 @@ func TestSummarizationService_SummarizeBatch_Errors(t *testing.T) {
 			},
 		},
 		func(opts request.Options) ([]Summarization, error) {
-			return newSummarizationService(opts).SummarizeBatch(SummarizationBatchRequest{
+			return newSummarizationService(opts).summarizeBatch(SummarizationBatchRequest{
 				Inputs: []string{"Long text one."},
 			})
 		},
@@ -298,7 +298,7 @@ func TestSummarizationService_SummarizeBatch_ModelFromOptions(t *testing.T) {
 		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
 	svc := newSummarizationService(opts)
 
-	result, err := svc.SummarizeBatch(SummarizationBatchRequest{
+	result, err := svc.summarizeBatch(SummarizationBatchRequest{
 		Inputs: []string{"Long text one."},
 	}, WithModel("override-model"))
 	require.NoError(t, err)

--- a/summarization_test.go
+++ b/summarization_test.go
@@ -1,0 +1,50 @@
+//go:build !integration
+
+package hfgo
+
+import (
+	"testing"
+
+	"github.com/Kardbord/hfgo/v4/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummarizationRequestClone_NestedIndependence(t *testing.T) {
+	t.Parallel()
+
+	origParams := SummarizationParameters{
+		CleanUpTokenizationSpaces: testutils.Ptr(false),
+		Truncation:                testutils.Ptr(SummarizationTruncationLongestFirst),
+		GenerateParameters:        map[string]any{"max_new_tokens": 5},
+	}
+	single := SummarizationRequest{Input: "a", Parameters: &origParams}
+	batch := SummarizationBatchRequest{Inputs: []string{"a", "b"}, Parameters: &origParams}
+
+	singleCloned := single.Clone()
+	batchCloned := batch.Clone()
+
+	*singleCloned.Parameters.Truncation = SummarizationTruncationOnlyFirst
+	singleCloned.Parameters.GenerateParameters["max_new_tokens"] = 99
+	*singleCloned.Parameters.CleanUpTokenizationSpaces = true
+	batchCloned.Inputs[0] = "zzz"
+	*batchCloned.Parameters.Truncation = SummarizationTruncationDoNotTruncate
+
+	require.Equal(t, SummarizationTruncationLongestFirst, *origParams.Truncation)
+	require.Equal(t, "a", single.Input)
+	require.Equal(t, []string{"a", "b"}, batch.Inputs)
+	require.False(t, *origParams.CleanUpTokenizationSpaces)
+	require.Equal(t, 5, origParams.GenerateParameters["max_new_tokens"])
+}
+
+func TestSummarizationRequestClone_Nil(t *testing.T) {
+	t.Parallel()
+
+	var r *SummarizationRequest
+	require.Empty(t, r.Clone())
+
+	var b *SummarizationBatchRequest
+	require.Empty(t, b.Clone())
+
+	var p *SummarizationParameters
+	require.Empty(t, p.Clone())
+}

--- a/text_classification.go
+++ b/text_classification.go
@@ -1,5 +1,7 @@
 package hfgo
 
+import "slices"
+
 // TextClassificationRequest represents a text classification
 // inference request to the API for a single input.
 type TextClassificationRequest struct {
@@ -53,4 +55,39 @@ type TextClassification struct {
 
 	// The corresponding probability.
 	Score float64 `json:"score"`
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *TextClassificationRequest) Clone() TextClassificationRequest {
+	if r == nil {
+		return TextClassificationRequest{}
+	}
+	out := *r
+	out.Parameters = cloneStructPtr(r.Parameters, (*TextClassificationParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *TextClassificationBatchRequest) Clone() TextClassificationBatchRequest {
+	if r == nil {
+		return TextClassificationBatchRequest{}
+	}
+	out := *r
+	out.Inputs = slices.Clone(r.Inputs)
+	out.Parameters = cloneStructPtr(r.Parameters, (*TextClassificationParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the parameters.
+func (p *TextClassificationParameters) Clone() TextClassificationParameters {
+	if p == nil {
+		return TextClassificationParameters{}
+	}
+	out := *p
+	out.FunctionToApply = clonePtr(p.FunctionToApply)
+	out.TopK = clonePtr(p.TopK)
+
+	return out
 }

--- a/text_classification_integration_test.go
+++ b/text_classification_integration_test.go
@@ -29,7 +29,7 @@ func TestTextClassification_LiveAPI(t *testing.T) {
 	)
 
 	const text = "This product is excellent and I love it!"
-	resp, err := client.ClassifyText().Classify(
+	resp, err := client.ClassifyText(
 		TextClassificationRequest{
 			Input: text,
 		},
@@ -68,7 +68,7 @@ func TestTextClassification_BatchLiveAPI(t *testing.T) {
 		"I enjoyed this film, though it had some minor flaws.",
 	}
 
-	resp, err := client.ClassifyText().ClassifyBatch(
+	resp, err := client.ClassifyTextBatch(
 		TextClassificationBatchRequest{
 			Inputs: inputs,
 		},
@@ -110,7 +110,7 @@ func TestTextClassification_WithParameters(t *testing.T) {
 
 	topK := 2
 	function := TextClassificationFuncSoftmax
-	resp, err := client.ClassifyText().Classify(
+	resp, err := client.ClassifyText(
 		TextClassificationRequest{
 			Input: "Excellent product!",
 			Parameters: &TextClassificationParameters{
@@ -154,7 +154,7 @@ func TestTextClassification_ContextCancellation(t *testing.T) {
 		WithContext(ctx),
 	)
 
-	resp, err := client.ClassifyText().Classify(
+	resp, err := client.ClassifyText(
 		TextClassificationRequest{
 			Input: "This is great!",
 		},
@@ -197,7 +197,7 @@ func TestTextClassification_VeryLargeBatch(t *testing.T) {
 		inputs[i] = "This product is " + sentiment + "!"
 	}
 
-	resp, err := client.ClassifyText().ClassifyBatch(
+	resp, err := client.ClassifyTextBatch(
 		TextClassificationBatchRequest{
 			Inputs: inputs,
 		},
@@ -248,7 +248,7 @@ func TestTextClassification_TopKResponseFormatQuirk(t *testing.T) {
 
 	// Test 1: Without TopK (unset) - API returns flat format which the SDK normalizes to per-input format
 	t.Run("without_topk_triggers_normalization", func(t *testing.T) {
-		resp, err := client.ClassifyText().ClassifyBatch(
+		resp, err := client.ClassifyTextBatch(
 			TextClassificationBatchRequest{
 				Inputs: inputs,
 				// TopK is not set (nil)
@@ -277,7 +277,7 @@ func TestTextClassification_TopKResponseFormatQuirk(t *testing.T) {
 	// Test 2: With TopK=1 - API returns per-input format; SDK skips normalization
 	t.Run("with_topk_1_skips_normalization", func(t *testing.T) {
 		topK := 1
-		resp, err := client.ClassifyText().ClassifyBatch(
+		resp, err := client.ClassifyTextBatch(
 			TextClassificationBatchRequest{
 				Inputs: inputs,
 				Parameters: &TextClassificationParameters{
@@ -304,7 +304,7 @@ func TestTextClassification_TopKResponseFormatQuirk(t *testing.T) {
 	// Test 3: With TopK=2 - API returns per-input format with multiple classifications; SDK skips normalization
 	t.Run("with_topk_2_skips_normalization", func(t *testing.T) {
 		topK := 2
-		resp, err := client.ClassifyText().ClassifyBatch(
+		resp, err := client.ClassifyTextBatch(
 			TextClassificationBatchRequest{
 				Inputs: inputs,
 				Parameters: &TextClassificationParameters{

--- a/text_classification_service.go
+++ b/text_classification_service.go
@@ -4,25 +4,18 @@ import (
 	"github.com/Kardbord/hfgo/v4/internal/request"
 )
 
-// TextClassificationService implements text classification
-// calls using the configured request options.
-type TextClassificationService struct {
+// textClassificationService implements text classification calls using the configured request options.
+type textClassificationService struct {
 	opts request.Options
 }
 
-// newTextClassificationService builds a TextClassificationService with a snapshot
-// of the provided options.
-func newTextClassificationService(opts request.Options) TextClassificationService {
-	return TextClassificationService{opts: opts}
+// newTextClassificationService builds a text classification service with a snapshot of the provided options.
+func newTextClassificationService(opts request.Options) textClassificationService {
+	return textClassificationService{opts: opts}
 }
 
-// Classify sends a text classification request and returns a text
-// classification response for a single input.
-//
-// For multiple classification inputs, use ClassifyBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (s TextClassificationService) Classify(
+// classify sends a text classification request for a single input and returns the classifications.
+func (s textClassificationService) classify(
 	req TextClassificationRequest,
 	opts ...Option,
 ) ([]TextClassification, error) {
@@ -49,17 +42,8 @@ func (s TextClassificationService) Classify(
 	return resp[0], nil
 }
 
-// ClassifyBatch sends a text classification request for a batch of inputs
-// and returns a list of text classification responses for each input in
-// the batch.
-//
-// NOTE: Batched inference is supported by the upstream API, but is not
-// officially documented; behavior may change without notice.
-//
-// Callers should check the length of the response list before indexing.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (s TextClassificationService) ClassifyBatch(
+// classifyBatch sends a text classification request for a batch of inputs and returns classifications per input.
+func (s textClassificationService) classifyBatch(
 	req TextClassificationBatchRequest,
 	opts ...Option,
 ) ([][]TextClassification, error) {

--- a/text_classification_service_test.go
+++ b/text_classification_service_test.go
@@ -167,7 +167,9 @@ func TestTextClassificationService_ClassifyBatch_ResponseVariations(t *testing.T
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel("test-model"),
 			)
 

--- a/text_classification_service_test.go
+++ b/text_classification_service_test.go
@@ -29,7 +29,7 @@ func TestTextClassificationService_Classify_SingleInput(t *testing.T) {
 		Input: "test text",
 	}
 
-	result, err := svc.Classify(req)
+	result, err := svc.classify(req)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result, 1)
@@ -58,7 +58,7 @@ func TestTextClassificationService_Classify_WithParameters(t *testing.T) {
 		},
 	}
 
-	result, err := svc.Classify(req)
+	result, err := svc.classify(req)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -92,7 +92,7 @@ func TestTextClassificationService_Classify_Errors(t *testing.T) {
 			},
 		},
 		func(opts request.Options) ([]TextClassification, error) {
-			return newTextClassificationService(opts).Classify(TextClassificationRequest{
+			return newTextClassificationService(opts).classify(TextClassificationRequest{
 				Input: "test text",
 			})
 		},
@@ -181,7 +181,7 @@ func TestTextClassificationService_ClassifyBatch_ResponseVariations(t *testing.T
 				}
 			}
 
-			result, err := svc.ClassifyBatch(req)
+			result, err := svc.classifyBatch(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result)
 			require.Len(t, result, tc.expectedOuterLength, tc.description)
@@ -219,7 +219,7 @@ func TestTextClassificationService_ClassifyBatch_NoModel(t *testing.T) {
 		Inputs: []string{"test text"},
 	}
 
-	result, err := svc.ClassifyBatch(req)
+	result, err := svc.classifyBatch(req)
 	require.Error(t, err)
 	require.Nil(t, result)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
@@ -246,7 +246,7 @@ func TestTextClassificationService_ClassifyBatch_ModelFromOptions(t *testing.T) 
 		Inputs: []string{"test text"},
 	}
 
-	result, err := svc.ClassifyBatch(req, WithModel("override-model"))
+	result, err := svc.classifyBatch(req, WithModel("override-model"))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/text_classification_service_test.go
+++ b/text_classification_service_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
-	"github.com/Kardbord/hfgo/v4/internal/request"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -20,16 +19,16 @@ func TestTextClassificationService_Classify_SingleInput(t *testing.T) {
 		`[[{"label":"positive","score":0.95}]]`,
 		nil,
 	)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-		WithModel("test-model")
-	svc := newTextClassificationService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+		WithModel("test-model"),
+	)
 
 	req := TextClassificationRequest{
 		Input: "test text",
 	}
 
-	result, err := svc.classify(req)
+	result, err := client.ClassifyText(req)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result, 1)
@@ -45,10 +44,10 @@ func TestTextClassificationService_Classify_WithParameters(t *testing.T) {
 		`[[{"label":"positive","score":0.95}]]`,
 		nil,
 	)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-		WithModel("test-model")
-	svc := newTextClassificationService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+		WithModel("test-model"),
+	)
 
 	topK := 2
 	req := TextClassificationRequest{
@@ -58,7 +57,7 @@ func TestTextClassificationService_Classify_WithParameters(t *testing.T) {
 		},
 	}
 
-	result, err := svc.classify(req)
+	result, err := client.ClassifyText(req)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -91,8 +90,8 @@ func TestTextClassificationService_Classify_Errors(t *testing.T) {
 				description:  "API error for nonexistent model",
 			},
 		},
-		func(opts request.Options) ([]TextClassification, error) {
-			return newTextClassificationService(opts).classify(TextClassificationRequest{
+		func(opts ...Option) ([]TextClassification, error) {
+			return NewClient(opts...).ClassifyText(TextClassificationRequest{
 				Input: "test text",
 			})
 		},
@@ -167,10 +166,10 @@ func TestTextClassificationService_ClassifyBatch_ResponseVariations(t *testing.T
 		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel("test-model")
-			svc := newTextClassificationService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel("test-model"),
+			)
 
 			req := TextClassificationBatchRequest{
 				Inputs: tc.inputs,
@@ -181,7 +180,7 @@ func TestTextClassificationService_ClassifyBatch_ResponseVariations(t *testing.T
 				}
 			}
 
-			result, err := svc.classifyBatch(req)
+			result, err := client.ClassifyTextBatch(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result)
 			require.Len(t, result, tc.expectedOuterLength, tc.description)
@@ -211,15 +210,15 @@ func TestTextClassificationService_ClassifyBatch_NoModel(t *testing.T) {
 	const batchTextClassificationResponseBody = `[[{"label":"positive","score":0.95}]]`
 
 	mt := testutils.NewJSONMockTransport(http.StatusOK, batchTextClassificationResponseBody, nil)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newTextClassificationService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
 	req := TextClassificationBatchRequest{
 		Inputs: []string{"test text"},
 	}
 
-	result, err := svc.classifyBatch(req)
+	result, err := client.ClassifyTextBatch(req)
 	require.Error(t, err)
 	require.Nil(t, result)
 	testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
@@ -238,15 +237,15 @@ func TestTextClassificationService_ClassifyBatch_ModelFromOptions(t *testing.T) 
 	const batchTextClassificationResponseBody = `[[{"label":"positive","score":0.95}]]`
 
 	mt := testutils.NewJSONMockTransport(http.StatusOK, batchTextClassificationResponseBody, nil)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newTextClassificationService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
 	req := TextClassificationBatchRequest{
 		Inputs: []string{"test text"},
 	}
 
-	result, err := svc.classifyBatch(req, WithModel("override-model"))
+	result, err := client.ClassifyTextBatch(req, WithModel("override-model"))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/text_classification_test.go
+++ b/text_classification_test.go
@@ -1,0 +1,87 @@
+//go:build !integration
+
+package hfgo
+
+import (
+	"testing"
+
+	"github.com/Kardbord/hfgo/v4/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTextClassificationRequestClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	req := TextClassificationRequest{
+		Input: "I feel great today!",
+		Parameters: &TextClassificationParameters{
+			FunctionToApply: testutils.Ptr(TextClassificationFuncSoftmax),
+			TopK:            testutils.Ptr(2),
+		},
+	}
+
+	cloned := req.Clone()
+
+	*cloned.Parameters.FunctionToApply = TextClassificationFuncSigmoid
+	*cloned.Parameters.TopK = 5
+	cloned.Input = "changed"
+
+	require.Equal(t, "I feel great today!", req.Input)
+	require.Equal(t, TextClassificationFuncSoftmax, *req.Parameters.FunctionToApply)
+	require.Equal(t, 2, *req.Parameters.TopK)
+	require.Equal(t, TextClassificationFuncSigmoid, *cloned.Parameters.FunctionToApply)
+	require.Equal(t, 5, *cloned.Parameters.TopK)
+}
+
+func TestTextClassificationBatchRequestClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	req := TextClassificationBatchRequest{
+		Inputs: []string{"text1", "text2"},
+		Parameters: &TextClassificationParameters{
+			FunctionToApply: testutils.Ptr(TextClassificationFuncNone),
+		},
+	}
+
+	cloned := req.Clone()
+
+	cloned.Inputs[0] = "changed"
+	*cloned.Parameters.FunctionToApply = TextClassificationFuncSoftmax
+
+	require.Equal(t, []string{"text1", "text2"}, req.Inputs)
+	require.Equal(t, TextClassificationFuncNone, *req.Parameters.FunctionToApply)
+	require.Equal(t, "changed", cloned.Inputs[0])
+	require.Equal(t, TextClassificationFuncSoftmax, *cloned.Parameters.FunctionToApply)
+}
+
+func TestTextClassificationParametersClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	params := &TextClassificationParameters{
+		FunctionToApply: testutils.Ptr(TextClassificationFuncSoftmax),
+		TopK:            testutils.Ptr(2),
+	}
+
+	cloned := params.Clone()
+
+	*cloned.FunctionToApply = TextClassificationFuncNone
+	*cloned.TopK = 3
+
+	require.Equal(t, TextClassificationFuncSoftmax, *params.FunctionToApply)
+	require.Equal(t, 2, *params.TopK)
+	require.Equal(t, TextClassificationFuncNone, *cloned.FunctionToApply)
+	require.Equal(t, 3, *cloned.TopK)
+}
+
+func TestTextClassificationClone_Nil(t *testing.T) {
+	t.Parallel()
+
+	var r *TextClassificationRequest
+	require.Empty(t, r.Clone())
+
+	var b *TextClassificationBatchRequest
+	require.Empty(t, b.Clone())
+
+	var p *TextClassificationParameters
+	require.Empty(t, p.Clone())
+}

--- a/zero_shot_text_classification.go
+++ b/zero_shot_text_classification.go
@@ -1,5 +1,7 @@
 package hfgo
 
+import "slices"
+
 // ZeroShotTextClassificationRequest represents a zero-shot text
 // classification request to the API for a single input.
 type ZeroShotTextClassificationRequest struct {
@@ -69,4 +71,40 @@ type zeroShotTextClassificationBatched struct {
 
 	// The classification scores.
 	Scores []float64 `json:"scores"`
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *ZeroShotTextClassificationRequest) Clone() ZeroShotTextClassificationRequest {
+	if r == nil {
+		return ZeroShotTextClassificationRequest{}
+	}
+	out := *r
+	out.Parameters = cloneStructPtr(r.Parameters, (*ZeroShotTextClassificationParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *ZeroShotTextClassificationBatchRequest) Clone() ZeroShotTextClassificationBatchRequest {
+	if r == nil {
+		return ZeroShotTextClassificationBatchRequest{}
+	}
+	out := *r
+	out.Inputs = slices.Clone(r.Inputs)
+	out.Parameters = cloneStructPtr(r.Parameters, (*ZeroShotTextClassificationParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the parameters.
+func (p *ZeroShotTextClassificationParameters) Clone() ZeroShotTextClassificationParameters {
+	if p == nil {
+		return ZeroShotTextClassificationParameters{}
+	}
+	out := *p
+	out.CandidateLabels = slices.Clone(p.CandidateLabels)
+	out.HypothesisTemplate = clonePtr(p.HypothesisTemplate)
+	out.MultiLabel = clonePtr(p.MultiLabel)
+
+	return out
 }

--- a/zero_shot_text_classification_integration_test.go
+++ b/zero_shot_text_classification_integration_test.go
@@ -32,7 +32,7 @@ func TestZeroShotTextClassification_LiveAPI(t *testing.T) {
 	const text = "This product is excellent and I love it!"
 	candidateLabels := []string{"positive", "negative", "neutral"}
 
-	resp, err := client.ZeroShotClassifyText().Classify(
+	resp, err := client.ZeroShotClassifyText(
 		ZeroShotTextClassificationRequest{
 			Input: text,
 			Parameters: &ZeroShotTextClassificationParameters{
@@ -72,7 +72,7 @@ func TestZeroShotTextClassification_BatchLiveAPI(t *testing.T) {
 
 	candidateLabels := []string{"positive", "negative", "neutral"}
 
-	resp, err := client.ZeroShotClassifyText().ClassifyBatch(
+	resp, err := client.ZeroShotClassifyTextBatch(
 		ZeroShotTextClassificationBatchRequest{
 			Inputs: inputs,
 			Parameters: &ZeroShotTextClassificationParameters{
@@ -117,7 +117,7 @@ func TestZeroShotTextClassification_WithHypothesisTemplate(t *testing.T) {
 	candidateLabels := []string{"positive", "negative"}
 	hypothesisTemplate := "This example is {}."
 
-	resp, err := client.ZeroShotClassifyText().Classify(
+	resp, err := client.ZeroShotClassifyText(
 		ZeroShotTextClassificationRequest{
 			Input: "I love this product!",
 			Parameters: &ZeroShotTextClassificationParameters{
@@ -153,7 +153,7 @@ func TestZeroShotTextClassification_WithMultiLabel(t *testing.T) {
 	candidateLabels := []string{"positive", "negative", "neutral"}
 	multiLabel := true
 
-	resp, err := client.ZeroShotClassifyText().Classify(
+	resp, err := client.ZeroShotClassifyText(
 		ZeroShotTextClassificationRequest{
 			Input: "This product is great and I love it!",
 			Parameters: &ZeroShotTextClassificationParameters{
@@ -203,7 +203,7 @@ func TestZeroShotTextClassification_VeryLargeBatch(t *testing.T) {
 
 	candidateLabels := []string{"positive", "negative", "neutral"}
 
-	resp, err := client.ZeroShotClassifyText().ClassifyBatch(
+	resp, err := client.ZeroShotClassifyTextBatch(
 		ZeroShotTextClassificationBatchRequest{
 			Inputs: inputs,
 			Parameters: &ZeroShotTextClassificationParameters{
@@ -247,7 +247,7 @@ func TestZeroShotTextClassification_MultipleCandidateLabels(t *testing.T) {
 		"confused",
 	}
 
-	resp, err := client.ZeroShotClassifyText().Classify(
+	resp, err := client.ZeroShotClassifyText(
 		ZeroShotTextClassificationRequest{
 			Input: "I absolutely love this product! It exceeded all my expectations!",
 			Parameters: &ZeroShotTextClassificationParameters{

--- a/zero_shot_text_classification_service.go
+++ b/zero_shot_text_classification_service.go
@@ -6,26 +6,20 @@ import (
 	"github.com/Kardbord/hfgo/v4/internal/request"
 )
 
-// ZeroShotTextClassificationService implements zero-shot
-// text classification calls using the configured request
-// options.
-type ZeroShotTextClassificationService struct {
+// zeroShotTextClassificationService implements zero-shot text classification
+// calls using the configured request options.
+type zeroShotTextClassificationService struct {
 	opts request.Options
 }
 
-// newZeroShotTextClassificationService builds a ZeroShotTextClassificationService with
-// a snapshot of the provided options.
-func newZeroShotTextClassificationService(opts request.Options) ZeroShotTextClassificationService {
-	return ZeroShotTextClassificationService{opts: opts}
+// newZeroShotTextClassificationService builds a zero-shot text classification service
+// with a snapshot of the provided options.
+func newZeroShotTextClassificationService(opts request.Options) zeroShotTextClassificationService {
+	return zeroShotTextClassificationService{opts: opts}
 }
 
-// Classify sends a zero-shot text classification request and returns a zero-shot
-// text classification response for a single input.
-//
-// For multiple inputs, use ClassifyBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (s ZeroShotTextClassificationService) Classify(
+// classify sends a zero-shot text classification request for a single input and returns the classifications.
+func (s zeroShotTextClassificationService) classify(
 	req ZeroShotTextClassificationRequest,
 	opts ...Option,
 ) ([]ZeroShotTextClassification, error) {
@@ -51,17 +45,9 @@ func (s ZeroShotTextClassificationService) Classify(
 	return resp, nil
 }
 
-// ClassifyBatch sends a zero-shot text classification request for a batch of inputs
-// and returns a list of zero-shot text classification responses for each input in the
-// batch.
-//
-// NOTE: Batched inference is supported by the upstream API, but is not
-// officially documented; behavior may change without notice.
-//
-// Callers should check the length of the response list before indexing.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
-func (s ZeroShotTextClassificationService) ClassifyBatch(
+// classifyBatch sends a zero-shot text classification request for a batch of inputs
+// and returns classifications for each input.
+func (s zeroShotTextClassificationService) classifyBatch(
 	req ZeroShotTextClassificationBatchRequest,
 	opts ...Option,
 ) ([][]ZeroShotTextClassification, error) {

--- a/zero_shot_text_classification_service_test.go
+++ b/zero_shot_text_classification_service_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
-	"github.com/Kardbord/hfgo/v4/internal/request"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -21,10 +20,10 @@ func TestZeroShotTextClassificationService_Classify_SingleInput(t *testing.T) {
 		zeroShotSingleClassificationResponseBody,
 		nil,
 	)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-		WithModel("test-model")
-	svc := newZeroShotTextClassificationService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+		WithModel("test-model"),
+	)
 
 	candidateLabels := []string{"positive", "negative", "neutral"}
 	req := ZeroShotTextClassificationRequest{
@@ -34,7 +33,7 @@ func TestZeroShotTextClassificationService_Classify_SingleInput(t *testing.T) {
 		},
 	}
 
-	result, err := svc.classify(req)
+	result, err := client.ZeroShotClassifyText(req)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result, 1)
@@ -79,12 +78,12 @@ func TestZeroShotTextClassificationService_Classify_CandidateLabelValidation(t *
 				zeroShotSingleClassificationResponseBody,
 				nil,
 			)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel("nonexistent-model")
-			svc := newZeroShotTextClassificationService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel("nonexistent-model"),
+			)
 
-			result, err := svc.classify(tc.req)
+			result, err := client.ZeroShotClassifyText(tc.req)
 			testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 			require.Nil(t, result, tc.description)
 			require.Nil(
@@ -118,10 +117,8 @@ func TestZeroShotTextClassificationService_Classify_Errors(t *testing.T) {
 				description:  "API error for nonexistent model",
 			},
 		},
-		func(opts request.Options) ([]ZeroShotTextClassification, error) {
-			return newZeroShotTextClassificationService(
-				opts,
-			).classify(ZeroShotTextClassificationRequest{
+		func(opts ...Option) ([]ZeroShotTextClassification, error) {
+			return NewClient(opts...).ZeroShotClassifyText(ZeroShotTextClassificationRequest{
 				Input: "test text",
 				Parameters: &ZeroShotTextClassificationParameters{
 					CandidateLabels: []string{"positive", "negative"},
@@ -179,10 +176,10 @@ func TestZeroShotTextClassificationService_ClassifyBatch_InputVariations(t *test
 		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel("test-model")
-			svc := newZeroShotTextClassificationService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel("test-model"),
+			)
 
 			candidateLabels := []string{"positive", "negative", "neutral"}
 			req := ZeroShotTextClassificationBatchRequest{
@@ -192,7 +189,7 @@ func TestZeroShotTextClassificationService_ClassifyBatch_InputVariations(t *test
 				},
 			}
 
-			result, err := svc.classifyBatch(req)
+			result, err := client.ZeroShotClassifyTextBatch(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result)
 			require.Len(t, result, tc.expectedOuterLength, tc.description)
@@ -249,12 +246,12 @@ func TestZeroShotTextClassificationService_ClassifyBatch_CandidateLabelValidatio
 				zeroShotBatchClassificationResponseBody,
 				nil,
 			)
-			opts := request.NewOptions().
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }).
-				WithModel("nonexistent-model")
-			svc := newZeroShotTextClassificationService(opts)
+			client := NewClient(
+				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithModel("nonexistent-model"),
+			)
 
-			result, err := svc.classifyBatch(tc.req)
+			result, err := client.ZeroShotClassifyTextBatch(tc.req)
 			testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 			require.Nil(t, result, tc.description)
 			require.Nil(
@@ -288,10 +285,8 @@ func TestZeroShotTextClassificationService_ClassifyBatch_Errors(t *testing.T) {
 				description:  "API error for nonexistent model",
 			},
 		},
-		func(opts request.Options) ([][]ZeroShotTextClassification, error) {
-			return newZeroShotTextClassificationService(
-				opts,
-			).classifyBatch(ZeroShotTextClassificationBatchRequest{
+		func(opts ...Option) ([][]ZeroShotTextClassification, error) {
+			return NewClient(opts...).ZeroShotClassifyTextBatch(ZeroShotTextClassificationBatchRequest{
 				Inputs: []string{"test text"},
 				Parameters: &ZeroShotTextClassificationParameters{
 					CandidateLabels: []string{"positive", "negative"},
@@ -311,9 +306,9 @@ func TestZeroShotTextClassificationService_ClassifyBatch_ModelFromOptions(t *tes
 		zeroShotBatchSingleTestTextResponseBody,
 		nil,
 	)
-	opts := request.NewOptions().
-		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) })
-	svc := newZeroShotTextClassificationService(opts)
+	client := NewClient(
+		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+	)
 
 	candidateLabels := []string{"positive", "negative"}
 	req := ZeroShotTextClassificationBatchRequest{
@@ -323,7 +318,7 @@ func TestZeroShotTextClassificationService_ClassifyBatch_ModelFromOptions(t *tes
 		},
 	}
 
-	result, err := svc.classifyBatch(req, WithModel("override-model"))
+	result, err := client.ZeroShotClassifyTextBatch(req, WithModel("override-model"))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/zero_shot_text_classification_service_test.go
+++ b/zero_shot_text_classification_service_test.go
@@ -79,7 +79,9 @@ func TestZeroShotTextClassificationService_Classify_CandidateLabelValidation(t *
 				nil,
 			)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel("nonexistent-model"),
 			)
 
@@ -177,7 +179,9 @@ func TestZeroShotTextClassificationService_ClassifyBatch_InputVariations(t *test
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel("test-model"),
 			)
 
@@ -247,7 +251,9 @@ func TestZeroShotTextClassificationService_ClassifyBatch_CandidateLabelValidatio
 				nil,
 			)
 			client := NewClient(
-				WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
 				WithModel("nonexistent-model"),
 			)
 
@@ -286,7 +292,8 @@ func TestZeroShotTextClassificationService_ClassifyBatch_Errors(t *testing.T) {
 			},
 		},
 		func(opts ...Option) ([][]ZeroShotTextClassification, error) {
-			return NewClient(opts...).ZeroShotClassifyTextBatch(ZeroShotTextClassificationBatchRequest{
+			return NewClient(
+				opts...).ZeroShotClassifyTextBatch(ZeroShotTextClassificationBatchRequest{
 				Inputs: []string{"test text"},
 				Parameters: &ZeroShotTextClassificationParameters{
 					CandidateLabels: []string{"positive", "negative"},

--- a/zero_shot_text_classification_service_test.go
+++ b/zero_shot_text_classification_service_test.go
@@ -34,7 +34,7 @@ func TestZeroShotTextClassificationService_Classify_SingleInput(t *testing.T) {
 		},
 	}
 
-	result, err := svc.Classify(req)
+	result, err := svc.classify(req)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result, 1)
@@ -84,7 +84,7 @@ func TestZeroShotTextClassificationService_Classify_CandidateLabelValidation(t *
 				WithModel("nonexistent-model")
 			svc := newZeroShotTextClassificationService(opts)
 
-			result, err := svc.Classify(tc.req)
+			result, err := svc.classify(tc.req)
 			testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 			require.Nil(t, result, tc.description)
 			require.Nil(
@@ -121,7 +121,7 @@ func TestZeroShotTextClassificationService_Classify_Errors(t *testing.T) {
 		func(opts request.Options) ([]ZeroShotTextClassification, error) {
 			return newZeroShotTextClassificationService(
 				opts,
-			).Classify(ZeroShotTextClassificationRequest{
+			).classify(ZeroShotTextClassificationRequest{
 				Input: "test text",
 				Parameters: &ZeroShotTextClassificationParameters{
 					CandidateLabels: []string{"positive", "negative"},
@@ -192,7 +192,7 @@ func TestZeroShotTextClassificationService_ClassifyBatch_InputVariations(t *test
 				},
 			}
 
-			result, err := svc.ClassifyBatch(req)
+			result, err := svc.classifyBatch(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result)
 			require.Len(t, result, tc.expectedOuterLength, tc.description)
@@ -254,7 +254,7 @@ func TestZeroShotTextClassificationService_ClassifyBatch_CandidateLabelValidatio
 				WithModel("nonexistent-model")
 			svc := newZeroShotTextClassificationService(opts)
 
-			result, err := svc.ClassifyBatch(tc.req)
+			result, err := svc.classifyBatch(tc.req)
 			testutils.AssertSDKErrorKind(t, err, hferrors.SDKErrorKindConfiguration)
 			require.Nil(t, result, tc.description)
 			require.Nil(
@@ -291,7 +291,7 @@ func TestZeroShotTextClassificationService_ClassifyBatch_Errors(t *testing.T) {
 		func(opts request.Options) ([][]ZeroShotTextClassification, error) {
 			return newZeroShotTextClassificationService(
 				opts,
-			).ClassifyBatch(ZeroShotTextClassificationBatchRequest{
+			).classifyBatch(ZeroShotTextClassificationBatchRequest{
 				Inputs: []string{"test text"},
 				Parameters: &ZeroShotTextClassificationParameters{
 					CandidateLabels: []string{"positive", "negative"},
@@ -323,7 +323,7 @@ func TestZeroShotTextClassificationService_ClassifyBatch_ModelFromOptions(t *tes
 		},
 	}
 
-	result, err := svc.ClassifyBatch(req, WithModel("override-model"))
+	result, err := svc.classifyBatch(req, WithModel("override-model"))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/zero_shot_text_classification_test.go
+++ b/zero_shot_text_classification_test.go
@@ -1,0 +1,94 @@
+//go:build !integration
+
+package hfgo
+
+import (
+	"testing"
+
+	"github.com/Kardbord/hfgo/v4/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZeroShotTextClassificationRequestClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	req := ZeroShotTextClassificationRequest{
+		Input: "I love this product",
+		Parameters: &ZeroShotTextClassificationParameters{
+			CandidateLabels:    []string{"positive", "negative", "neutral"},
+			HypothesisTemplate: testutils.Ptr("This example is {}."),
+			MultiLabel:         testutils.Ptr(false),
+		},
+	}
+
+	cloned := req.Clone()
+
+	cloned.Parameters.CandidateLabels[0] = "great"
+	*cloned.Parameters.HypothesisTemplate = "changed {}"
+	*cloned.Parameters.MultiLabel = true
+	cloned.Input = "changed"
+
+	require.Equal(t, "I love this product", req.Input)
+	require.Equal(t, []string{"positive", "negative", "neutral"}, req.Parameters.CandidateLabels)
+	require.Equal(t, "This example is {}.", *req.Parameters.HypothesisTemplate)
+	require.False(t, *req.Parameters.MultiLabel)
+	require.Equal(t, "great", cloned.Parameters.CandidateLabels[0])
+	require.True(t, *cloned.Parameters.MultiLabel)
+}
+
+func TestZeroShotTextClassificationBatchRequestClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	req := ZeroShotTextClassificationBatchRequest{
+		Inputs: []string{"text1", "text2"},
+		Parameters: &ZeroShotTextClassificationParameters{
+			CandidateLabels: []string{"positive", "negative"},
+			MultiLabel:      testutils.Ptr(false),
+		},
+	}
+
+	cloned := req.Clone()
+
+	cloned.Inputs[0] = "changed"
+	cloned.Parameters.CandidateLabels[0] = "great"
+
+	require.Equal(t, []string{"text1", "text2"}, req.Inputs)
+	require.Equal(t, []string{"positive", "negative"}, req.Parameters.CandidateLabels)
+	require.Equal(t, "changed", cloned.Inputs[0])
+	require.Equal(t, "great", cloned.Parameters.CandidateLabels[0])
+}
+
+func TestZeroShotTextClassificationParametersClone_Deep(t *testing.T) {
+	t.Parallel()
+
+	params := &ZeroShotTextClassificationParameters{
+		CandidateLabels:    []string{"positive", "negative"},
+		HypothesisTemplate: testutils.Ptr("This example is {}."),
+		MultiLabel:         testutils.Ptr(true),
+	}
+
+	cloned := params.Clone()
+
+	cloned.CandidateLabels[0] = "great"
+	*cloned.HypothesisTemplate = "changed {}"
+	*cloned.MultiLabel = false
+
+	require.Equal(t, []string{"positive", "negative"}, params.CandidateLabels)
+	require.Equal(t, "This example is {}.", *params.HypothesisTemplate)
+	require.True(t, *params.MultiLabel)
+	require.Equal(t, "great", cloned.CandidateLabels[0])
+	require.False(t, *cloned.MultiLabel)
+}
+
+func TestZeroShotTextClassificationClone_Nil(t *testing.T) {
+	t.Parallel()
+
+	var r *ZeroShotTextClassificationRequest
+	require.Empty(t, r.Clone())
+
+	var b *ZeroShotTextClassificationBatchRequest
+	require.Empty(t, b.Clone())
+
+	var p *ZeroShotTextClassificationParameters
+	require.Empty(t, p.Clone())
+}


### PR DESCRIPTION
## TL;DR:
Replaces the per-task service layer with a flat, client-centric API and strengthens the request-safety/concurrency model. 

## Changes
**Flattened services into `Client` methods**. Every inference task is now invoked directly on `Client` instead of via a `*Service` accessor:
- `client.Chat().Complete(req)` → `client.Chat(req)`
- `client.Chat().CompleteStream(req)` → `client.ChatStream(req)`
- Etc.

The service types are now unexported implementation details; the public behavioral docs (model/provider precedence, etc.) live on the `Client` methods. `Client.Raw()` / `RawService` remains the one deliberate public escape hatch for arbitrary raw HTTP requests.

**By-value requests + deep `Clone()`**: `Client.Chat`/`ChatStream` now take `ChatRequest` by value so the SDK can provide greater assurance that it never mutates the caller's payload. Every request DTO (chat, fill-mask, summarization, text/zero-shot classification requests and params) gains a deep `Clone()` backed by `clonePtr`/`cloneStructPtr`/`cloneSlice`, enabling safe concurrent reuse of a template, e.g. `go client.Chat(req.Clone(), ...)`.

**Docs & tests**: README, `doc.go`, `docs/architecture.md`, `CONTRIBUTING.md`, `AGENTS.md`, examples, and all tests updated to the flat call style; test suite now routes through the public `Client` methods; added `Clone` coverage (including a concurrent-invocation test) and `TestNewClient_Defaults`.

## Breaking changes

- `client.Chat().Complete(&ChatRequest)` → `client.Chat(req)` (value, not pointer)
- Exported `*Service` types removed from the public surface (internal now)
- The former "chat request is nil" config error is gone (nil no longer
  expressible); zero-value requests surface model/messages validation errors

No major rev necessary because v4 is still in draft.

## Clone Caveat

`SummarizationParameters.GenerateParameters` values are shared across `Clone` because their types are not statically known (documented).