### PR TITLE
feat: Add translation task support & fix Bruno request headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -218,6 +218,36 @@ func (c Client) SummarizeBatch(
 	return newSummarizationService(c.opts).summarizeBatch(req, opts...)
 }
 
+// Translate sends a translation request and returns the translation output
+// for a single input.
+//
+// The API always returns a list for translation; a single input yields a
+// one-element list rather than a bare translation object.
+//
+// For multiple inputs, use TranslateBatch.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) Translate(req TranslationRequest, opts ...Option) ([]Translation, error) {
+	return newTranslationService(c.opts).translate(req, opts...)
+}
+
+// TranslateBatch sends a translation request for a batch of inputs and returns
+// a flat list of translation outputs, one for each input in the batch, in the
+// same order as the inputs.
+//
+// NOTE: Batched inference is supported by the upstream API, but is not
+// officially documented; behavior may change without notice. The response is
+// a flat list (one translation per input) — not a nested list — consistent with
+// how the API returns a list even for a single input.
+//
+// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
+func (c Client) TranslateBatch(
+	req TranslationBatchRequest,
+	opts ...Option,
+) ([]Translation, error) {
+	return newTranslationService(c.opts).translateBatch(req, opts...)
+}
+
 // Raw returns the raw HTTP request service for this client. Unlike the other
 // endpoints, which are exposed directly as Client methods, the raw path remains
 // namespaced under RawService: it is the advanced escape hatch for endpoints the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@ The SDK follows a strict immutability pattern for concurrency safety:
    - `ZeroShotClassifyText` / `ZeroShotClassifyTextBatch`: Zero-shot text classification
    - `FillMask` / `FillMaskBatch`: Mask filling
    - `Summarize` / `SummarizeBatch`: Summarization
+   - `Translate` / `TranslateBatch`: Translation
    - The former per-domain service types are unexported implementation details; callers interact only with the Client
    - `Client.Raw()` returns the `RawService` escape hatch for arbitrary endpoints (see below); it is the deliberate exception to the flat-method design
 
@@ -416,6 +417,24 @@ Batch text summarization for multiple inputs.
 - Validates that a model is configured
 - The API returns a flat list of `Summarization` outputs (one per input, in order) rather than a nested list, consistent with how it returns a list even for a single input
 
+### Translation
+
+#### Translate(req TranslationRequest, opts ...Option) ([]Translation, error)
+Single text translation.
+
+**Behavior**:
+- Applies per-request options
+- Validates that a model is configured
+- Returns a flat list of `Translation` outputs for the single input
+
+#### TranslateBatch(req TranslationBatchRequest, opts ...Option) ([]Translation, error)
+Batch text translation for multiple inputs.
+
+**Behavior**:
+- Applies per-request options
+- Validates that a model is configured
+- The API returns a flat list of `Translation` outputs (one per input, in order) rather than a nested list, consistent with how it returns a list even for a single input
+
 ### RawService (escape hatch)
 
 Created via `client.Raw()`. For raw HTTP requests without type-safe JSON handling. This is the only endpoint path exposed as a service rather than as flat Client methods; it is the advanced escape hatch for endpoints the SDK does not model, and its broader method matrix is easier to discover grouped here.
@@ -525,7 +544,7 @@ Request DTOs (e.g. `ChatRequest`) are passed to Client methods **by value**, and
    go client.Chat(req.Clone(), ...)      // each goroutine passes its own copy
    go client.ChatStream(req.Clone(), ...)
    ```
-   `Clone()` is a **deep** copy: every slice gets new backing storage and every pointer a new pointee, so a clone shares nothing with its source. Exception: the value of an entry in `SummarizationParameters.GenerateParameters` (`map[string]any`) is shared, because its type is not known statically.
+   `Clone()` is a **deep** copy: every slice gets new backing storage and every pointer a new pointee, so a clone shares nothing with its source. Exception: the value of an entry in `SummarizationParameters.GenerateParameters` or `TranslationParameters.GenerateParameters` (`map[string]any`) is shared, because its type is not known statically.
 3. **No reuse**: Simply build a fresh request per call or per goroutine and never share request objects.
 
 **Never**: share one mutable request object across goroutines and mutate it while calls are in flight — that is a data race the SDK cannot observe or prevent.

--- a/examples/translation/basic/translation.go
+++ b/examples/translation/basic/translation.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Kardbord/hfgo/v4"
+)
+
+func main() {
+	token := os.Getenv("HF_TOKEN")
+	if token == "" {
+		log.Fatal("HF_TOKEN environment variable is not set")
+	}
+
+	// Create a new client with your API token and desired model
+	client := hfgo.NewClient(
+		hfgo.WithToken(token),
+		hfgo.WithModel("google-t5/t5-small"),
+	)
+
+	input := "Hello, how are you doing today?"
+
+	fmt.Println("Translating input:")
+	PrintJSON(input)
+	fmt.Println("...")
+
+	// Make the translation request with source and target languages
+	translations, err := client.Translate(
+		hfgo.TranslationRequest{
+			Input: input,
+		},
+	)
+	if err != nil {
+		log.Fatalf("error running translation: %v\n", err)
+	}
+
+	fmt.Println("Results:")
+	PrintJSON(translations)
+}
+
+func PrintJSON[T any](v T) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		log.Fatalf("error printing JSON: %v\n", err)
+	}
+
+	fmt.Println(string(b))
+}

--- a/examples/translation/batch/translation_batch.go
+++ b/examples/translation/batch/translation_batch.go
@@ -30,7 +30,7 @@ func main() {
 	PrintJSON(inputs)
 	fmt.Println("...")
 
-	// Make the batched translation request with source and target languages
+	// Make the batched translation request
 	translations, err := client.TranslateBatch(
 		hfgo.TranslationBatchRequest{
 			Inputs: inputs,

--- a/examples/translation/batch/translation_batch.go
+++ b/examples/translation/batch/translation_batch.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Kardbord/hfgo/v4"
+)
+
+func main() {
+	token := os.Getenv("HF_TOKEN")
+	if token == "" {
+		log.Fatal("HF_TOKEN environment variable is not set")
+	}
+
+	// Create a new client with your API token and desired model
+	client := hfgo.NewClient(
+		hfgo.WithToken(token),
+		hfgo.WithModel("google-t5/t5-small"),
+	)
+
+	inputs := []string{
+		"Good morning, everyone.",
+		"See you tomorrow.",
+	}
+
+	fmt.Println("Translating inputs:")
+	PrintJSON(inputs)
+	fmt.Println("...")
+
+	// Make the batched translation request with source and target languages
+	translations, err := client.TranslateBatch(
+		hfgo.TranslationBatchRequest{
+			Inputs: inputs,
+		},
+	)
+	if err != nil {
+		log.Fatalf("error running batched translation: %v\n", err)
+	}
+
+	fmt.Println("Results:")
+	PrintJSON(translations)
+}
+
+func PrintJSON[T any](v T) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		log.Fatalf("error printing JSON: %v\n", err)
+	}
+
+	fmt.Println(string(b))
+}

--- a/examples/translation/params/translation_params.go
+++ b/examples/translation/params/translation_params.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Kardbord/hfgo/v4"
+)
+
+func main() {
+	token := os.Getenv("HF_TOKEN")
+	if token == "" {
+		log.Fatal("HF_TOKEN environment variable is not set")
+	}
+
+	// Create a new client with your API token and desired model
+	client := hfgo.NewClient(
+		hfgo.WithToken(token),
+		hfgo.WithModel("google-t5/t5-small"),
+	)
+
+	input := "The weather is lovely and sunny today."
+
+	cleanUp := true
+	truncation := hfgo.TranslationTruncationOnlyFirst
+
+	fmt.Println("Translating input:")
+	PrintJSON(input)
+	fmt.Println("...")
+
+	// Make the translation request with custom parameters
+	translations, err := client.Translate(
+		hfgo.TranslationRequest{
+			Input: input,
+			Parameters: &hfgo.TranslationParameters{
+				CleanUpTokenizationSpaces: &cleanUp,
+				Truncation:                &truncation,
+			},
+		},
+	)
+	if err != nil {
+		log.Fatalf("error running translation: %v\n", err)
+	}
+
+	fmt.Println("Results:")
+	PrintJSON(translations)
+}
+
+func PrintJSON[T any](v T) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		log.Fatalf("error printing JSON: %v\n", err)
+	}
+
+	fmt.Println(string(b))
+}

--- a/service_response_variations_test.go
+++ b/service_response_variations_test.go
@@ -1,0 +1,117 @@
+//go:build !integration
+
+package hfgo
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Kardbord/hfgo/v4/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// singleResponseVariationCase describes one expected response shape for an
+// endpoint whose API returns a flat list of text-bearing outputs.
+type singleResponseVariationCase struct {
+	// name is the subtest name.
+	name string
+	// responseBody is the mocked JSON response body.
+	responseBody string
+	// wantLen is the expected length of the returned list.
+	wantLen int
+	// wantText is the expected text of the first element, when wantLen > 0.
+	wantText string
+	// description explains the scenario; it is used in failure messages.
+	description string
+}
+
+// runSingleResponseVariations drives a table of single-input response shapes
+// against call, which performs one SDK request and returns its flat result
+// list. text extracts the text field from a single element for comparison.
+//
+// The shared scaffolding (mock transport, client construction, len/text
+// assertions) lives here so endpoints that share the flat-list-of-text output
+// shape — e.g. translation and summarization — do not duplicate it.
+func runSingleResponseVariations[Req, Res any](
+	t *testing.T,
+	cases []singleResponseVariationCase,
+	buildReq func() Req,
+	call func(client Client, req Req) ([]Res, error),
+	text func(Res) string,
+) {
+	t.Helper()
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
+			client := NewClient(
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
+				WithModel("test-model"),
+			)
+
+			result, err := call(client, buildReq())
+			require.NoError(t, err, tc.description)
+			require.NotNil(t, result, tc.description)
+			require.Len(t, result, tc.wantLen, tc.description)
+
+			if tc.wantLen > 0 {
+				require.Equal(t, tc.wantText, text(result[0]), tc.description)
+			}
+		})
+	}
+}
+
+// batchResponseVariationCase describes one expected response shape for a
+// batch call that returns a flat list of text-bearing outputs, one per input.
+type batchResponseVariationCase struct {
+	// name is the subtest name.
+	name string
+	// responseBody is the mocked JSON response body.
+	responseBody string
+	// want is the expected text of each element, in order.
+	want []string
+	// description explains the scenario; it is used in failure messages.
+	description string
+}
+
+// runBatchResponseVariations drives a table of batch response shapes against
+// call, which performs one SDK request and returns its flat result list. text
+// extracts the text field from a single element for comparison.
+//
+// The shared scaffolding lives here for the same reason as
+// runSingleResponseVariations: endpoints sharing the flat-list-of-text output
+// shape should not duplicate it.
+func runBatchResponseVariations[Req, Res any](
+	t *testing.T,
+	cases []batchResponseVariationCase,
+	buildReq func() Req,
+	call func(client Client, req Req) ([]Res, error),
+	text func(Res) string,
+) {
+	t.Helper()
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			mt := testutils.NewJSONMockTransport(http.StatusOK, tc.responseBody, nil)
+			client := NewClient(
+				WithHTTPClientFactory(
+					func() http.Client { return testutils.NewMockHTTPClient(mt) },
+				),
+				WithModel("test-model"),
+			)
+
+			result, err := call(client, buildReq())
+			require.NoError(t, err, tc.description)
+			require.NotNil(t, result, tc.description)
+			require.Len(t, result, len(tc.want), tc.description)
+
+			for j, r := range result {
+				require.Equal(t, tc.want[j], text(r), tc.description)
+			}
+		})
+	}
+}

--- a/tools/bruno/hfgo/audio-classification/audio-classification-params.bru
+++ b/tools/bruno/hfgo/audio-classification/audio-classification-params.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_audio}})
   parameters: {"function_to_apply": "softmax", "top_k": 5}

--- a/tools/bruno/hfgo/audio-classification/audio-classification-single.bru
+++ b/tools/bruno/hfgo/audio-classification/audio-classification-single.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_audio}})
 }

--- a/tools/bruno/hfgo/automatic-speech-recognition/automatic-speech-recognition-params.bru
+++ b/tools/bruno/hfgo/automatic-speech-recognition/automatic-speech-recognition-params.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_audio}})
   parameters: {"return_timestamps": true}

--- a/tools/bruno/hfgo/automatic-speech-recognition/automatic-speech-recognition-single.bru
+++ b/tools/bruno/hfgo/automatic-speech-recognition/automatic-speech-recognition-single.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_audio}})
 }

--- a/tools/bruno/hfgo/chat-completion/chat-completion-non-streaming.bru
+++ b/tools/bruno/hfgo/chat-completion/chat-completion-non-streaming.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "model": "{{model_chat_completion}}",

--- a/tools/bruno/hfgo/chat-completion/chat-completion-params.bru
+++ b/tools/bruno/hfgo/chat-completion/chat-completion-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "model": "{{model_chat_completion}}",

--- a/tools/bruno/hfgo/chat-completion/chat-completion-streaming.bru
+++ b/tools/bruno/hfgo/chat-completion/chat-completion-streaming.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: text/event-stream
+  Content-Type: application/json
+}
+
 body:json {
   {
     "model": "{{model_chat_completion}}",

--- a/tools/bruno/hfgo/feature-extraction/feature-extraction-batch.bru
+++ b/tools/bruno/hfgo/feature-extraction/feature-extraction-batch.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": [

--- a/tools/bruno/hfgo/feature-extraction/feature-extraction-params.bru
+++ b/tools/bruno/hfgo/feature-extraction/feature-extraction-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "The capital of France is Paris, a city on the Seine.",

--- a/tools/bruno/hfgo/feature-extraction/feature-extraction-single.bru
+++ b/tools/bruno/hfgo/feature-extraction/feature-extraction-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "What is the capital of France?",

--- a/tools/bruno/hfgo/fill-mask/fill-mask-batch.bru
+++ b/tools/bruno/hfgo/fill-mask/fill-mask-batch.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": [

--- a/tools/bruno/hfgo/fill-mask/fill-mask-params.bru
+++ b/tools/bruno/hfgo/fill-mask/fill-mask-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "The quick brown fox jumps over the [MASK] dog.",

--- a/tools/bruno/hfgo/fill-mask/fill-mask-single.bru
+++ b/tools/bruno/hfgo/fill-mask/fill-mask-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "The capital of France is [MASK].",

--- a/tools/bruno/hfgo/image-classification/image-classification-params.bru
+++ b/tools/bruno/hfgo/image-classification/image-classification-params.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
   parameters: {"function_to_apply": "softmax", "top_k": 5}

--- a/tools/bruno/hfgo/image-classification/image-classification-single.bru
+++ b/tools/bruno/hfgo/image-classification/image-classification-single.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
 }

--- a/tools/bruno/hfgo/image-segmentation/image-segmentation-params.bru
+++ b/tools/bruno/hfgo/image-segmentation/image-segmentation-params.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: image/png
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
   parameters: {"mask_threshold": 0.5, "subtask": "panoptic", "threshold": 0.5}

--- a/tools/bruno/hfgo/image-segmentation/image-segmentation-params.bru
+++ b/tools/bruno/hfgo/image-segmentation/image-segmentation-params.bru
@@ -11,7 +11,7 @@ post {
 }
 
 headers {
-  Accept: image/png
+  Accept: application/json
 }
 
 body:multipart-form {

--- a/tools/bruno/hfgo/image-segmentation/image-segmentation-single.bru
+++ b/tools/bruno/hfgo/image-segmentation/image-segmentation-single.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: image/png
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
 }

--- a/tools/bruno/hfgo/image-segmentation/image-segmentation-single.bru
+++ b/tools/bruno/hfgo/image-segmentation/image-segmentation-single.bru
@@ -11,7 +11,7 @@ post {
 }
 
 headers {
-  Accept: image/png
+  Accept: application/json
 }
 
 body:multipart-form {

--- a/tools/bruno/hfgo/image-text-to-text/image-text-to-text-params.bru
+++ b/tools/bruno/hfgo/image-text-to-text/image-text-to-text-params.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
   text: Describe this image in detail.

--- a/tools/bruno/hfgo/image-text-to-text/image-text-to-text-single.bru
+++ b/tools/bruno/hfgo/image-text-to-text/image-text-to-text-single.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
   text: What is shown in this image?

--- a/tools/bruno/hfgo/image-to-image/image-to-image-params.bru
+++ b/tools/bruno/hfgo/image-to-image/image-to-image-params.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: image/png
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
   parameters: {"prompt": "Turn this into a watercolor painting", "guidance_scale": 7.5, "num_inference_steps": 30, "negative_prompt": "blurry, low quality"}

--- a/tools/bruno/hfgo/image-to-image/image-to-image-single.bru
+++ b/tools/bruno/hfgo/image-to-image/image-to-image-single.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: image/png
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
 }

--- a/tools/bruno/hfgo/object-detection/object-detection-params.bru
+++ b/tools/bruno/hfgo/object-detection/object-detection-params.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
   parameters: {"threshold": 0.6}

--- a/tools/bruno/hfgo/object-detection/object-detection-single.bru
+++ b/tools/bruno/hfgo/object-detection/object-detection-single.bru
@@ -10,6 +10,10 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+}
+
 body:multipart-form {
   inputs: @file({{sample_png}})
 }

--- a/tools/bruno/hfgo/question-answering/question-answering-batch.bru
+++ b/tools/bruno/hfgo/question-answering/question-answering-batch.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": [

--- a/tools/bruno/hfgo/question-answering/question-answering-params.bru
+++ b/tools/bruno/hfgo/question-answering/question-answering-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": {

--- a/tools/bruno/hfgo/question-answering/question-answering-single.bru
+++ b/tools/bruno/hfgo/question-answering/question-answering-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": {

--- a/tools/bruno/hfgo/summarization/summarization-batch.bru
+++ b/tools/bruno/hfgo/summarization/summarization-batch.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": [

--- a/tools/bruno/hfgo/summarization/summarization-params.bru
+++ b/tools/bruno/hfgo/summarization/summarization-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "The industrial revolution transformed agriculture, manufacturing, mining, and transport, leading to massive social and economic changes.",

--- a/tools/bruno/hfgo/summarization/summarization-single.bru
+++ b/tools/bruno/hfgo/summarization/summarization-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "Hugging Face is a company that develops tools for machine learning. It is best known for its Transformers library and the Model Hub, which hosts thousands of pretrained models.",

--- a/tools/bruno/hfgo/table-question-answering/table-question-answering-params.bru
+++ b/tools/bruno/hfgo/table-question-answering/table-question-answering-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": {

--- a/tools/bruno/hfgo/table-question-answering/table-question-answering-single.bru
+++ b/tools/bruno/hfgo/table-question-answering/table-question-answering-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": {

--- a/tools/bruno/hfgo/text-classification/text-classification-batch.bru
+++ b/tools/bruno/hfgo/text-classification/text-classification-batch.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": [

--- a/tools/bruno/hfgo/text-classification/text-classification-params.bru
+++ b/tools/bruno/hfgo/text-classification/text-classification-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "The stock market rallied today on strong earnings.",

--- a/tools/bruno/hfgo/text-classification/text-classification-single.bru
+++ b/tools/bruno/hfgo/text-classification/text-classification-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "I am very happy today.",

--- a/tools/bruno/hfgo/text-generation/text-generation-batch.bru
+++ b/tools/bruno/hfgo/text-generation/text-generation-batch.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": [

--- a/tools/bruno/hfgo/text-generation/text-generation-params.bru
+++ b/tools/bruno/hfgo/text-generation/text-generation-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "Explain the concept of recursion briefly.",

--- a/tools/bruno/hfgo/text-generation/text-generation-single.bru
+++ b/tools/bruno/hfgo/text-generation/text-generation-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "Once upon a time, in a faraway land",

--- a/tools/bruno/hfgo/text-to-image/text-to-image-params.bru
+++ b/tools/bruno/hfgo/text-to-image/text-to-image-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: image/png
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "A majestic lion in the savanna.",

--- a/tools/bruno/hfgo/text-to-image/text-to-image-single.bru
+++ b/tools/bruno/hfgo/text-to-image/text-to-image-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: image/png
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "A serene mountain landscape at sunset.",

--- a/tools/bruno/hfgo/text-to-video/text-to-video-params.bru
+++ b/tools/bruno/hfgo/text-to-video/text-to-video-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "A dog running through a sunny park.",

--- a/tools/bruno/hfgo/text-to-video/text-to-video-single.bru
+++ b/tools/bruno/hfgo/text-to-video/text-to-video-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "A futuristic city with flying cars.",

--- a/tools/bruno/hfgo/token-classification/token-classification-batch.bru
+++ b/tools/bruno/hfgo/token-classification/token-classification-batch.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": [

--- a/tools/bruno/hfgo/token-classification/token-classification-params.bru
+++ b/tools/bruno/hfgo/token-classification/token-classification-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "Microsoft was founded by Bill Gates and Paul Allen in 1975.",

--- a/tools/bruno/hfgo/token-classification/token-classification-single.bru
+++ b/tools/bruno/hfgo/token-classification/token-classification-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "My name is Sarah and I work at OpenAI in San Francisco.",

--- a/tools/bruno/hfgo/translation/translation-batch.bru
+++ b/tools/bruno/hfgo/translation/translation-batch.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": [
@@ -18,7 +23,7 @@ body:json {
     ],
     "parameters": {
       "src_lang": "en",
-      "tgt_lang": "es"
+      "tgt_lang": "de"
     }
   }
 }

--- a/tools/bruno/hfgo/translation/translation-params.bru
+++ b/tools/bruno/hfgo/translation/translation-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "The weather is lovely and sunny today.",
@@ -17,10 +22,7 @@ body:json {
       "src_lang": "en",
       "tgt_lang": "de",
       "clean_up_tokenization_spaces": true,
-      "truncation": "only_first",
-      "generate_parameters": {
-        "max_new_tokens": 60
-      }
+      "truncation": "only_first"
     }
   }
 }

--- a/tools/bruno/hfgo/translation/translation-single.bru
+++ b/tools/bruno/hfgo/translation/translation-single.bru
@@ -10,12 +10,17 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "Hello, how are you doing today?",
     "parameters": {
       "src_lang": "en",
-      "tgt_lang": "fr"
+      "tgt_lang": "de"
     }
   }
 }

--- a/tools/bruno/hfgo/zero-shot-classification/zero-shot-classification-batch.bru
+++ b/tools/bruno/hfgo/zero-shot-classification/zero-shot-classification-batch.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": [

--- a/tools/bruno/hfgo/zero-shot-classification/zero-shot-classification-params.bru
+++ b/tools/bruno/hfgo/zero-shot-classification/zero-shot-classification-params.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "The stock is trending upward this quarter.",

--- a/tools/bruno/hfgo/zero-shot-classification/zero-shot-classification-single.bru
+++ b/tools/bruno/hfgo/zero-shot-classification/zero-shot-classification-single.bru
@@ -10,6 +10,11 @@ post {
   auth: inherit
 }
 
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
 body:json {
   {
     "inputs": "The movie was absolutely fantastic and thrilling.",

--- a/translation.go
+++ b/translation.go
@@ -1,0 +1,115 @@
+package hfgo
+
+import (
+	"maps"
+	"slices"
+)
+
+// TranslationRequest represents a translation
+// inference request to the API for a single input.
+type TranslationRequest struct {
+	// The text to translate.
+	// Required.
+	Input string `json:"inputs"`
+
+	// Additional inference parameters for translation.
+	Parameters *TranslationParameters `json:"parameters,omitempty"`
+}
+
+// TranslationBatchRequest represents a batched translation
+// inference request to the API for multiple inputs.
+//
+// NOTE: Batched inference is supported by the upstream API, but is not
+// officially documented; behavior may change without notice.
+type TranslationBatchRequest struct {
+	// The texts to translate.
+	// Required.
+	Inputs []string `json:"inputs"`
+
+	// Additional inference parameters for translation.
+	Parameters *TranslationParameters `json:"parameters,omitempty"`
+}
+
+// TranslationParameters specify additional inference
+// parameters for translation tasks.
+type TranslationParameters struct {
+	// Whether to clean up the potential extra spaces in the text output.
+	CleanUpTokenizationSpaces *bool `json:"clean_up_tokenization_spaces,omitempty"`
+
+	// The source language of the text. Required for models that can
+	// translate from multiple languages.
+	SrcLang *string `json:"src_lang,omitempty"`
+
+	// The target language to translate to. Required for models that can
+	// translate to multiple languages.
+	TgtLang *string `json:"tgt_lang,omitempty"`
+
+	// The truncation strategy to use.
+	Truncation *string `json:"truncation,omitempty"`
+
+	// GenerateParameters provides additional parametrization of the text
+	// generation algorithm (e.g. "max_new_tokens", "temperature", "top_k").
+	//
+	// It is exposed because it is part of the upstream inference schema, but the
+	// set of valid arguments is not documented by Hugging Face and may depend on
+	// the model being used. Invalid or unsupported arguments can be rejected by
+	// the API.
+	GenerateParameters map[string]any `json:"generate_parameters,omitempty"`
+}
+
+const (
+	// TranslationTruncationDoNotTruncate keeps the input as-is without any truncation.
+	TranslationTruncationDoNotTruncate = "do_not_truncate"
+	// TranslationTruncationLongestFirst truncates the longest side first when the input exceeds the model's maximum length.
+	TranslationTruncationLongestFirst = "longest_first"
+	// TranslationTruncationOnlyFirst trims the input on the first (left) side when it exceeds the model's maximum length.
+	TranslationTruncationOnlyFirst = "only_first"
+	// TranslationTruncationOnlySecond trims the input on the second (right) side when it exceeds the model's maximum length.
+	TranslationTruncationOnlySecond = "only_second"
+)
+
+// Translation represents a translation output.
+type Translation struct {
+	// The translated text.
+	TranslationText string `json:"translation_text"`
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *TranslationRequest) Clone() TranslationRequest {
+	if r == nil {
+		return TranslationRequest{}
+	}
+	out := *r
+	out.Parameters = cloneStructPtr(r.Parameters, (*TranslationParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the request.
+func (r *TranslationBatchRequest) Clone() TranslationBatchRequest {
+	if r == nil {
+		return TranslationBatchRequest{}
+	}
+	out := *r
+	out.Inputs = slices.Clone(r.Inputs)
+	out.Parameters = cloneStructPtr(r.Parameters, (*TranslationParameters).Clone)
+
+	return out
+}
+
+// Clone returns a deep defensive copy of the parameters. The GenerateParameters
+// map is copied as a new map, but its values are shared because their types are
+// not known statically.
+func (p *TranslationParameters) Clone() TranslationParameters {
+	if p == nil {
+		return TranslationParameters{}
+	}
+	out := *p
+	out.CleanUpTokenizationSpaces = clonePtr(p.CleanUpTokenizationSpaces)
+	out.SrcLang = clonePtr(p.SrcLang)
+	out.TgtLang = clonePtr(p.TgtLang)
+	out.Truncation = clonePtr(p.Truncation)
+	out.GenerateParameters = maps.Clone(p.GenerateParameters)
+
+	return out
+}

--- a/translation_integration_test.go
+++ b/translation_integration_test.go
@@ -1,0 +1,138 @@
+//go:build integration
+
+package hfgo
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTranslation_LiveAPI tests a basic translation request against the live HF API.
+// This test requires the HF_TOKEN environment variable to be set.
+func TestTranslation_LiveAPI(t *testing.T) {
+	apiToken := os.Getenv("HF_TOKEN")
+	require.NotEmpty(t, apiToken, "HF_TOKEN must be set")
+
+	const model = "google-t5/t5-small"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client := NewClient(
+		WithToken(apiToken),
+		WithModel(model),
+		WithContext(ctx),
+	)
+
+	resp, err := client.Translate(
+		TranslationRequest{
+			Input: "Hello, how are you doing today?",
+		},
+	)
+
+	require.NoError(t, err, "translation should succeed")
+	require.NotNil(t, resp, "response should not be nil")
+	require.NotEmpty(t, resp, "response should have content")
+	require.NotEmpty(t, resp[0].TranslationText, "translation text should not be empty")
+}
+
+// TestTranslation_BatchLiveAPI tests batch translation against the live HF API.
+// This test requires the HF_TOKEN environment variable to be set.
+func TestTranslation_BatchLiveAPI(t *testing.T) {
+	apiToken := os.Getenv("HF_TOKEN")
+	require.NotEmpty(t, apiToken, "HF_TOKEN must be set")
+
+	const model = "google-t5/t5-small"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	client := NewClient(
+		WithToken(apiToken),
+		WithModel(model),
+		WithContext(ctx),
+	)
+
+	resp, err := client.TranslateBatch(
+		TranslationBatchRequest{
+			Inputs: []string{
+				"Good morning, everyone.",
+				"See you tomorrow.",
+			},
+		},
+	)
+
+	require.NoError(t, err, "batch translation should succeed")
+	require.NotNil(t, resp, "response should not be nil")
+	require.Len(t, resp, 2, "response should have 2 translations")
+
+	for i, translation := range resp {
+		require.NotEmpty(t, translation.TranslationText, "translation text should not be empty")
+		t.Logf("Translation %d: %s", i, translation.TranslationText)
+	}
+}
+
+// TestTranslation_WithParameters tests translation with various parameters.
+// This test requires the HF_TOKEN environment variable to be set.
+func TestTranslation_WithParameters(t *testing.T) {
+	apiToken := os.Getenv("HF_TOKEN")
+	require.NotEmpty(t, apiToken, "HF_TOKEN must be set")
+
+	const model = "google-t5/t5-small"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	client := NewClient(
+		WithToken(apiToken),
+		WithModel(model),
+		WithContext(ctx),
+	)
+
+	cleanUp := true
+	truncation := TranslationTruncationOnlyFirst
+	resp, err := client.Translate(
+		TranslationRequest{
+			Input: "The weather is lovely and sunny today.",
+			Parameters: &TranslationParameters{
+				CleanUpTokenizationSpaces: &cleanUp,
+				Truncation:                &truncation,
+			},
+		},
+	)
+
+	require.NoError(t, err, "translation with parameters should succeed")
+	require.NotNil(t, resp, "response should not be nil")
+	require.NotEmpty(t, resp, "response should have content")
+	require.NotEmpty(t, resp[0].TranslationText, "translation text should not be empty")
+}
+
+// TestTranslation_ContextCancellation tests that context cancellation is respected.
+// This test requires the HF_TOKEN environment variable to be set.
+func TestTranslation_ContextCancellation(t *testing.T) {
+	apiToken := os.Getenv("HF_TOKEN")
+	require.NotEmpty(t, apiToken, "HF_TOKEN must be set")
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := NewClient(
+		WithToken(apiToken),
+		WithModel("google-t5/t5-small"),
+		WithContext(ctx),
+	)
+
+	resp, err := client.Translate(
+		TranslationRequest{
+			Input: "Hello, how are you?",
+		},
+	)
+
+	require.Error(t, err, "request with cancelled context should fail")
+	require.Nil(t, resp, "response should be nil for cancelled context")
+}

--- a/translation_service.go
+++ b/translation_service.go
@@ -1,0 +1,39 @@
+package hfgo
+
+import (
+	"github.com/Kardbord/hfgo/v4/internal/request"
+)
+
+// translationService implements translation calls using the configured request options.
+type translationService struct {
+	opts request.Options
+}
+
+// newTranslationService builds a translation service with a snapshot of the provided options.
+func newTranslationService(opts request.Options) translationService {
+	return translationService{opts: opts}
+}
+
+// translate sends a translation request for a single input and returns the output.
+func (s translationService) translate(
+	req TranslationRequest,
+	opts ...Option,
+) ([]Translation, error) {
+	return doModelInference[TranslationRequest, []Translation](
+		s.opts.With(opts...),
+		"translation",
+		req,
+	)
+}
+
+// translateBatch sends a translation request for a batch of inputs and returns a flat list of outputs.
+func (s translationService) translateBatch(
+	req TranslationBatchRequest,
+	opts ...Option,
+) ([]Translation, error) {
+	return doModelInference[TranslationBatchRequest, []Translation](
+		s.opts.With(opts...),
+		"translation",
+		req,
+	)
+}

--- a/translation_service_test.go
+++ b/translation_service_test.go
@@ -11,18 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSummarizationService_Summarize_ResponseVariations(t *testing.T) {
+func TestTranslationService_Translate_ResponseVariations(t *testing.T) {
 	t.Parallel()
 
-	runSingleResponseVariations(
-		t,
+	runSingleResponseVariations(t,
 		[]singleResponseVariationCase{
 			{
-				name:         "single summary",
-				responseBody: `[{"summary_text":"A concise summary."}]`,
+				name:         "single translation",
+				responseBody: `[{"translation_text":"Bonjour, comment allez-vous aujourd'hui ?"}]`,
 				wantLen:      1,
-				wantText:     "A concise summary.",
-				description:  "a single summary is returned",
+				wantText:     "Bonjour, comment allez-vous aujourd'hui ?",
+				description:  "a single translation is returned",
 			},
 			{
 				name:         "empty response",
@@ -31,25 +30,27 @@ func TestSummarizationService_Summarize_ResponseVariations(t *testing.T) {
 				description:  "empty response passes through as an empty list",
 			},
 			{
-				name:         "multiple summaries",
-				responseBody: `[{"summary_text":"One."},{"summary_text":"Two."}]`,
+				name:         "multiple translations",
+				responseBody: `[{"translation_text":"Un."},{"translation_text":"Deux."}]`,
 				wantLen:      2,
-				wantText:     "One.",
-				description:  "multiple summaries in one response pass through",
+				wantText:     "Un.",
+				description:  "multiple translations in one response pass through",
 			},
 		},
-		func() SummarizationRequest { return SummarizationRequest{Input: "Some long text."} },
-		func(c Client, req SummarizationRequest) ([]Summarization, error) { return c.Summarize(req) },
-		func(s Summarization) string { return s.SummaryText },
+		func() TranslationRequest { return TranslationRequest{Input: "Hello, how are you?"} },
+		func(c Client, req TranslationRequest) ([]Translation, error) { return c.Translate(req) },
+		func(tr Translation) string { return tr.TranslationText },
 	)
 }
 
-func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
+func TestTranslationService_Translate_ParameterSerialization(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name        string
 		cleanUp     *bool
+		srcLang     *string
+		tgtLang     *string
 		truncation  *string
 		generate    map[string]any
 		want        map[string]any
@@ -66,27 +67,39 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 			description: "clean_up_tokenization_spaces maps to its JSON key",
 		},
 		{
+			name:        "source language",
+			srcLang:     testutils.Ptr("en"),
+			want:        map[string]any{"src_lang": "en"},
+			description: "src_lang maps to its JSON key",
+		},
+		{
+			name:        "target language",
+			tgtLang:     testutils.Ptr("fr"),
+			want:        map[string]any{"tgt_lang": "fr"},
+			description: "tgt_lang maps to its JSON key",
+		},
+		{
 			name:        "truncation do_not_truncate",
-			truncation:  testutils.Ptr(SummarizationTruncationDoNotTruncate),
-			want:        map[string]any{"truncation": SummarizationTruncationDoNotTruncate},
+			truncation:  testutils.Ptr(TranslationTruncationDoNotTruncate),
+			want:        map[string]any{"truncation": TranslationTruncationDoNotTruncate},
 			description: "do_not_truncate constant serializes correctly",
 		},
 		{
 			name:        "truncation longest_first",
-			truncation:  testutils.Ptr(SummarizationTruncationLongestFirst),
-			want:        map[string]any{"truncation": SummarizationTruncationLongestFirst},
+			truncation:  testutils.Ptr(TranslationTruncationLongestFirst),
+			want:        map[string]any{"truncation": TranslationTruncationLongestFirst},
 			description: "longest_first constant serializes correctly",
 		},
 		{
 			name:        "truncation only_first",
-			truncation:  testutils.Ptr(SummarizationTruncationOnlyFirst),
-			want:        map[string]any{"truncation": SummarizationTruncationOnlyFirst},
+			truncation:  testutils.Ptr(TranslationTruncationOnlyFirst),
+			want:        map[string]any{"truncation": TranslationTruncationOnlyFirst},
 			description: "only_first constant serializes correctly",
 		},
 		{
 			name:        "truncation only_second",
-			truncation:  testutils.Ptr(SummarizationTruncationOnlySecond),
-			want:        map[string]any{"truncation": SummarizationTruncationOnlySecond},
+			truncation:  testutils.Ptr(TranslationTruncationOnlySecond),
+			want:        map[string]any{"truncation": TranslationTruncationOnlySecond},
 			description: "only_second constant serializes correctly",
 		},
 		{
@@ -103,11 +116,15 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 		{
 			name:       "all parameters",
 			cleanUp:    testutils.Ptr(true),
-			truncation: testutils.Ptr(SummarizationTruncationOnlyFirst),
+			srcLang:    testutils.Ptr("en"),
+			tgtLang:    testutils.Ptr("de"),
+			truncation: testutils.Ptr(TranslationTruncationOnlyFirst),
 			generate:   map[string]any{"max_new_tokens": 60},
 			want: map[string]any{
 				"clean_up_tokenization_spaces": true,
-				"truncation":                   SummarizationTruncationOnlyFirst,
+				"src_lang":                     "en",
+				"tgt_lang":                     "de",
+				"truncation":                   TranslationTruncationOnlyFirst,
 				"generate_parameters":          map[string]any{"max_new_tokens": float64(60)},
 			},
 			description: "all parameters serialize together",
@@ -119,7 +136,7 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mt := testutils.NewJSONMockTransport(
 				http.StatusOK,
-				`[{"summary_text":"A concise summary."}]`,
+				`[{"translation_text":"Test translation."}]`,
 				nil,
 			)
 			client := NewClient(
@@ -129,16 +146,19 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 				WithModel("test-model"),
 			)
 
-			req := SummarizationRequest{Input: "Some long text."}
-			if tc.cleanUp != nil || tc.truncation != nil || tc.generate != nil {
-				req.Parameters = &SummarizationParameters{
+			req := TranslationRequest{Input: "Hello, how are you?"}
+			if tc.cleanUp != nil || tc.srcLang != nil || tc.tgtLang != nil ||
+				tc.truncation != nil || tc.generate != nil {
+				req.Parameters = &TranslationParameters{
 					CleanUpTokenizationSpaces: tc.cleanUp,
+					SrcLang:                   tc.srcLang,
+					TgtLang:                   tc.tgtLang,
 					Truncation:                tc.truncation,
 					GenerateParameters:        tc.generate,
 				}
 			}
 
-			result, err := client.Summarize(req)
+			result, err := client.Translate(req)
 			require.NoError(t, err, tc.description)
 			require.NotNil(t, result, tc.description)
 
@@ -155,7 +175,7 @@ func TestSummarizationService_Summarize_ParameterSerialization(t *testing.T) {
 	}
 }
 
-func TestSummarizationService_Summarize_Errors(t *testing.T) {
+func TestTranslationService_Translate_Errors(t *testing.T) {
 	t.Parallel()
 
 	runErrorCases(t,
@@ -163,7 +183,7 @@ func TestSummarizationService_Summarize_Errors(t *testing.T) {
 			{
 				name:         "no model configured",
 				statusCode:   http.StatusOK,
-				responseBody: `[{"summary_text":"A concise summary."}]`,
+				responseBody: `[{"translation_text":"Test translation."}]`,
 				want:         testutils.WantErrSDK,
 				sdkErrKind:   hferrors.SDKErrorKindConfiguration,
 				description:  "SDK error when model is missing",
@@ -177,15 +197,15 @@ func TestSummarizationService_Summarize_Errors(t *testing.T) {
 				description:  "API error for nonexistent model",
 			},
 		},
-		func(opts ...Option) ([]Summarization, error) {
-			return NewClient(opts...).Summarize(SummarizationRequest{
-				Input: "Some long text that should be summarized.",
+		func(opts ...Option) ([]Translation, error) {
+			return NewClient(opts...).Translate(TranslationRequest{
+				Input: "Hello, how are you?",
 			})
 		},
 	)
 }
 
-func TestSummarizationService_SummarizeBatch_ResponseVariations(t *testing.T) {
+func TestTranslationService_TranslateBatch_ResponseVariations(t *testing.T) {
 	t.Parallel()
 
 	runBatchResponseVariations(
@@ -193,15 +213,15 @@ func TestSummarizationService_SummarizeBatch_ResponseVariations(t *testing.T) {
 		[]batchResponseVariationCase{
 			{
 				name:         "single input",
-				responseBody: `[{"summary_text":"Summary one."}]`,
-				want:         []string{"Summary one."},
-				description:  "a single batched input returns one summary",
+				responseBody: `[{"translation_text":"Bonjour."}]`,
+				want:         []string{"Bonjour."},
+				description:  "a single batched input returns one translation",
 			},
 			{
 				name:         "multiple inputs",
-				responseBody: `[{"summary_text":"Summary one."},{"summary_text":"Summary two."}]`,
-				want:         []string{"Summary one.", "Summary two."},
-				description:  "each batched input returns its own flat summary",
+				responseBody: `[{"translation_text":"Bonjour."},{"translation_text":"À demain."}]`,
+				want:         []string{"Bonjour.", "À demain."},
+				description:  "each batched input returns its own flat translation",
 			},
 			{
 				name:         "empty response",
@@ -210,15 +230,15 @@ func TestSummarizationService_SummarizeBatch_ResponseVariations(t *testing.T) {
 				description:  "empty response passes through as an empty list",
 			},
 		},
-		func() SummarizationBatchRequest {
-			return SummarizationBatchRequest{Inputs: []string{"Long text one.", "Long text two."}}
+		func() TranslationBatchRequest {
+			return TranslationBatchRequest{Inputs: []string{"Hello.", "See you tomorrow."}}
 		},
-		func(c Client, req SummarizationBatchRequest) ([]Summarization, error) { return c.SummarizeBatch(req) },
-		func(s Summarization) string { return s.SummaryText },
+		func(c Client, req TranslationBatchRequest) ([]Translation, error) { return c.TranslateBatch(req) },
+		func(tr Translation) string { return tr.TranslationText },
 	)
 }
 
-func TestSummarizationService_SummarizeBatch_Errors(t *testing.T) {
+func TestTranslationService_TranslateBatch_Errors(t *testing.T) {
 	t.Parallel()
 
 	runErrorCases(t,
@@ -226,7 +246,7 @@ func TestSummarizationService_SummarizeBatch_Errors(t *testing.T) {
 			{
 				name:         "no model configured",
 				statusCode:   http.StatusOK,
-				responseBody: `[{"summary_text":"Summary one."}]`,
+				responseBody: `[{"translation_text":"Bonjour."}]`,
 				want:         testutils.WantErrSDK,
 				sdkErrKind:   hferrors.SDKErrorKindConfiguration,
 				description:  "SDK error when model is missing",
@@ -240,28 +260,28 @@ func TestSummarizationService_SummarizeBatch_Errors(t *testing.T) {
 				description:  "API error for nonexistent model",
 			},
 		},
-		func(opts ...Option) ([]Summarization, error) {
-			return NewClient(opts...).SummarizeBatch(SummarizationBatchRequest{
-				Inputs: []string{"Long text one."},
+		func(opts ...Option) ([]Translation, error) {
+			return NewClient(opts...).TranslateBatch(TranslationBatchRequest{
+				Inputs: []string{"Hello."},
 			})
 		},
 	)
 }
 
-func TestSummarizationService_SummarizeBatch_ModelFromOptions(t *testing.T) {
+func TestTranslationService_TranslateBatch_ModelFromOptions(t *testing.T) {
 	t.Parallel()
 
 	mt := testutils.NewJSONMockTransport(
 		http.StatusOK,
-		`[{"summary_text":"Summary one."}]`,
+		`[{"translation_text":"Bonjour."}]`,
 		nil,
 	)
 	client := NewClient(
 		WithHTTPClientFactory(func() http.Client { return testutils.NewMockHTTPClient(mt) }),
 	)
 
-	result, err := client.SummarizeBatch(SummarizationBatchRequest{
-		Inputs: []string{"Long text one."},
+	result, err := client.TranslateBatch(TranslationBatchRequest{
+		Inputs: []string{"Hello."},
 	}, WithModel("override-model"))
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/translation_test.go
+++ b/translation_test.go
@@ -1,0 +1,54 @@
+//go:build !integration
+
+package hfgo
+
+import (
+	"testing"
+
+	"github.com/Kardbord/hfgo/v4/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslationRequestClone_NestedIndependence(t *testing.T) {
+	t.Parallel()
+
+	origParams := TranslationParameters{
+		CleanUpTokenizationSpaces: testutils.Ptr(false),
+		SrcLang:                   testutils.Ptr("en"),
+		TgtLang:                   testutils.Ptr("fr"),
+		Truncation:                testutils.Ptr(TranslationTruncationLongestFirst),
+		GenerateParameters:        map[string]any{"max_new_tokens": 5},
+	}
+	single := TranslationRequest{Input: "a", Parameters: &origParams}
+	batch := TranslationBatchRequest{Inputs: []string{"a", "b"}, Parameters: &origParams}
+
+	singleCloned := single.Clone()
+	batchCloned := batch.Clone()
+
+	*singleCloned.Parameters.Truncation = TranslationTruncationOnlyFirst
+	*singleCloned.Parameters.SrcLang = "de"
+	*singleCloned.Parameters.TgtLang = "es"
+	singleCloned.Parameters.GenerateParameters["max_new_tokens"] = 99
+	*singleCloned.Parameters.CleanUpTokenizationSpaces = true
+	batchCloned.Inputs[0] = "zzz"
+	*batchCloned.Parameters.Truncation = TranslationTruncationDoNotTruncate
+
+	require.Equal(t, TranslationTruncationLongestFirst, *origParams.Truncation)
+	require.Equal(t, "a", single.Input)
+	require.Equal(t, []string{"a", "b"}, batch.Inputs)
+	require.False(t, *origParams.CleanUpTokenizationSpaces)
+	require.Equal(t, 5, origParams.GenerateParameters["max_new_tokens"])
+}
+
+func TestTranslationRequestClone_Nil(t *testing.T) {
+	t.Parallel()
+
+	var r *TranslationRequest
+	require.Empty(t, r.Clone())
+
+	var b *TranslationBatchRequest
+	require.Empty(t, b.Clone())
+
+	var p *TranslationParameters
+	require.Empty(t, p.Clone())
+}


### PR DESCRIPTION
#### Translation support (`translation.go`, `client.go`)
- Add `Client.Translate` and `Client.TranslateBatch`, backed by an unexported `translationService` using the shared `doModelInference` helper (same model-POST pattern as summarization).
- Add `TranslationRequest` / `TranslationBatchRequest` DTOs, the `Translation` output type, truncation constants, and deep `Clone()` methods.
- `SrcLang` / `TgtLang` exposed for models that translate between multiple languages; `GenerateParameters` exposed as part of the upstream schema (arguments are undocumented and model-dependent).
- Document the flat-list response quirk: a single input yields a one-element list, and batched input yields a one-translation-per-input flat list (not a nested list).
- Tests: unit response-variation, parameter-serialization, error, and integration tests; plus `basic`/`batch`/`params` examples. `docs/architecture.md` updated.

#### Test refactor
- Extract generic `runSingleResponseVariations` / `runBatchResponseVariations` response-variation helpers (in `service_response_variations_test.go`) and route summarization tests through them, removing cross-file duplication (dupl linter).

#### Bruno header fix
- Bruno sends a default `Accept: application/json, text/plain, */*` that the Hugging Face router rejects (it only accepts exact media types). Add explicit headers blocks:
  - JSON text tasks → `Accept: application/json`, `Content-Type: application/json`
  - `chat-completion-streaming` → `Accept: text/event-stream`
  - Image-producing tasks (text-to-image, image-to-image, image-segmentation) → `Accept: image/png`
  - Multipart file-upload tasks → `Accept` only (Content-Type left to Bruno's multipart)
- Drop the undocumented `generate_parameters` from `translation-params` so the example stays within documented parameters.
