### PR TITLE
ci: add top-level permissions to workflows for OSSF Scorecard compliance

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,6 +8,9 @@ on:
       - v*-draft
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-actionlint:
     name: Run actionlint

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   review:
     name: OpenCode PR Review
@@ -15,6 +18,7 @@ jobs:
        github.event.comment.author_association == 'MEMBER')
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout (bootstrap for local actions)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,9 @@ on:
     - cron: "45 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,11 +4,15 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     name: Triage issue
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout (bootstrap for local actions)

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -6,6 +6,9 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   opencode:
     name: Run OpenCode
@@ -18,6 +21,7 @@ jobs:
        github.event.comment.author_association == 'MEMBER')
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout (bootstrap for local actions)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,15 @@ on:
       - v*-draft
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # ====================================================================
       # Select release configuration based on branch


### PR DESCRIPTION
Add restrictive top-level `permissions: contents: read` to 6 workflows that were missing top-level permissions, and move write permissions to job-level where needed. This addresses the Token-Permissions check (score: 0) from the OSSF Scorecard.

Affected workflows:
- actionlint.yml: add top-level permissions
- code-review.yml: add top-level + fix job-level (contents: read)
- codeql-analysis.yml: add top-level permissions
- issue-triage.yml: add top-level + fix job-level (contents: read)
- opencode.yml: add top-level + fix job-level (contents: read)
- release.yml: move contents:write and pull-requests:write to job-level