### PR TITLE
feat!: Implement provider-aware endpoint resolution with Provider interface

### DIFF
--- a/chat_service.go
+++ b/chat_service.go
@@ -84,7 +84,7 @@ func (s chatService) resolveEndpoint(
 		}
 	}
 
-	endpoint, err := provider.Endpoint("chat-completion", *req.Model)
+	endpoint, err := provider.Endpoint(TaskChatCompletion, *req.Model)
 	if err != nil {
 		return "", request.Options{}, err
 	}

--- a/chat_service.go
+++ b/chat_service.go
@@ -10,9 +10,6 @@ import (
 	"github.com/Kardbord/hfgo/v4/internal/request"
 )
 
-// EndpointChatCompletion specifies the chat completion endpoint.
-const EndpointChatCompletion = "/v1/chat/completions"
-
 // chatService implements chat completion calls using the configured request options.
 type chatService struct {
 	opts request.Options
@@ -23,60 +20,10 @@ func newChatService(opts request.Options) chatService {
 	return chatService{opts: opts}
 }
 
-// complete sends a chat completion request and returns a chat completion response.
-//
-//nolint:gocritic // hugeParam: complete takes the request by value so the SDK never mutates the caller's payload
-func (s chatService) complete(req ChatRequest, opts ...Option) (ChatResponse, error) {
-	optsOverride := s.opts.With(opts...)
-
-	resolveModel(&req, optsOverride)
-
-	if req.Stream != nil && *req.Stream {
-		return ChatResponse{}, &SDKError{
-			Kind:    SDKErrorKindConfiguration,
-			Message: "chat completion streaming is not supported; use a streaming chat method instead",
-			Err:     nil,
-		}
-	}
-
-	return request.DoJSON[ChatRequest, ChatResponse](
-		optsOverride,
-		http.MethodPost,
-		EndpointChatCompletion,
-		req,
-	)
-}
-
-// completeStream sends a chat completion request and returns a streaming response.
-//
-//nolint:gocritic // hugeParam: completeStream takes the request by value so the SDK never mutates the caller's payload
-func (s chatService) completeStream(req ChatRequest, opts ...Option) (*ChatStream, error) {
-	optsOverride := s.opts.With(opts...)
-
-	resolveModel(&req, optsOverride)
-
-	stream := true
-	req.Stream = &stream
-
-	streamResp, err := request.DoJSONStream[ChatRequest, ChatStreamResponse](
-		optsOverride,
-		http.MethodPost,
-		EndpointChatCompletion,
-		req,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ChatStream{
-		stream:       streamResp,
-		toolCallAccr: chatstream.ToolCallAccumulator{},
-	}, nil
-}
-
-// resolveModel resolves the model with precedence and applies the provider fallback.
+// resolveModel resolves the model with precedence and applies the provider suffix.
 // Model precedence: request > options > client.
-// Provider is applied as a fallback only if the resolved model doesn't already contain a provider.
+// Provider suffix is appended only if the model doesn't already contain a provider
+// (indicated by ":") and the provider is not the default HuggingFace provider.
 func resolveModel(payload *ChatRequest, optsOverride request.Options) {
 	// Resolve model with precedence: request > options > client
 	if payload.Model == nil || *payload.Model == "" {
@@ -92,18 +39,110 @@ func resolveModel(payload *ChatRequest, optsOverride request.Options) {
 
 // applyProvider applies the provider to the model if the model
 // doesn't already contain a provider (indicated by ":").
-func applyProvider(model *string, provider string) *string {
-	if model == nil || *model == "" || provider == "" {
+func applyProvider(model *string, provider Provider) *string {
+	if model == nil || *model == "" || provider == nil {
+		return model
+	}
+
+	if provider.ProviderSuffix() == "" {
 		return model
 	}
 
 	if !strings.Contains(*model, ":") {
-		newModel := fmt.Sprintf("%s:%s", *model, provider)
+		newModel := fmt.Sprintf("%s:%s", *model, provider.ProviderSuffix())
 
 		return &newModel
 	}
 
 	return model
+}
+
+// resolveEndpoint resolves the chat completion endpoint, validating the model
+// and provider. It returns the endpoint path and the resolved options override.
+func (s chatService) resolveEndpoint(
+	req *ChatRequest,
+	opts ...Option,
+) (string, request.Options, error) {
+	optsOverride := s.opts.With(opts...)
+
+	resolveModel(req, optsOverride)
+
+	if req.Model == nil || *req.Model == "" {
+		return "", request.Options{}, &SDKError{
+			Kind:    SDKErrorKindConfiguration,
+			Message: "the model option must be set for chat completion to succeed",
+			Err:     nil,
+		}
+	}
+
+	provider := optsOverride.Provider
+	if provider == nil {
+		return "", request.Options{}, &SDKError{
+			Kind:    SDKErrorKindConfiguration,
+			Message: "provider must not be nil",
+			Err:     nil,
+		}
+	}
+
+	endpoint, err := provider.Endpoint("chat-completion", *req.Model)
+	if err != nil {
+		return "", request.Options{}, err
+	}
+
+	return endpoint, optsOverride, nil
+}
+
+// complete sends a chat completion request and returns a chat completion response.
+//
+//nolint:gocritic // hugeParam: complete takes the request by value so the SDK never mutates the caller's payload
+func (s chatService) complete(req ChatRequest, opts ...Option) (ChatResponse, error) {
+	endpoint, optsOverride, err := s.resolveEndpoint(&req, opts...)
+	if err != nil {
+		return ChatResponse{}, err
+	}
+
+	if req.Stream != nil && *req.Stream {
+		return ChatResponse{}, &SDKError{
+			Kind:    SDKErrorKindConfiguration,
+			Message: "chat completion streaming is not supported; use a streaming chat method instead",
+			Err:     nil,
+		}
+	}
+
+	return request.DoJSON[ChatRequest, ChatResponse](
+		optsOverride,
+		http.MethodPost,
+		endpoint,
+		req,
+	)
+}
+
+// completeStream sends a chat completion request and returns a streaming response.
+//
+//nolint:gocritic // hugeParam: completeStream takes the request by value so the SDK never mutates the caller's payload
+func (s chatService) completeStream(req ChatRequest, opts ...Option) (*ChatStream, error) {
+	endpoint, optsOverride, err := s.resolveEndpoint(&req, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	stream := true
+	req.Stream = &stream
+
+	streamResp, err := request.DoJSONStream[ChatRequest, ChatStreamResponse](
+		optsOverride,
+		http.MethodPost,
+		endpoint,
+		req,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChatStream{
+		stream:       streamResp,
+		toolCallAccr: chatstream.ToolCallAccumulator{},
+	}, nil
 }
 
 // ChatStream wraps a streaming chat completion response.

--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -23,7 +23,7 @@ type mockProvider struct {
 	name string
 }
 
-func (p mockProvider) Endpoint(_, _ string) (string, error) {
+func (p mockProvider) Endpoint(_ Task, _ string) (string, error) {
 	return "", nil
 }
 

--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -566,137 +566,32 @@ func TestChatService_ProviderFallback(t *testing.T) {
 		optsProvider   Provider
 		reqModel       *string
 		wantModel      string
+		wantErr        bool
 		description    string
 	}
 
 	cases := []TestCase{
 		{
-			name:           "applies client provider to client model",
+			name:           "happy path with default HF provider",
 			clientModel:    "mistral-7b",
 			clientProvider: providers.HuggingFaceProvider{},
 			wantModel:      "mistral-7b",
-			description:    "client model + client provider",
+			description:    "end-to-end chat with HF provider (no suffix)",
 		},
 		{
-			name:         "applies request provider to request model",
-			clientModel:  "default-model",
-			reqModel:     testutils.Ptr("mistral-7b"),
-			optsProvider: providers.HuggingFaceProvider{},
-			wantModel:    "mistral-7b",
-			description:  "request model + request provider",
-		},
-		{
-			name:           "request provider overrides client provider",
-			clientModel:    "mistral-7b",
-			clientProvider: mockProvider{name: "mistral"},
-			optsProvider:   providers.HuggingFaceProvider{},
-			wantModel:      "mistral-7b",
-			description:    "request provider overrides client provider",
-		},
-		{
-			name:           "ignores provider when model already has provider",
-			clientModel:    "mistral-7b:mistral",
-			clientProvider: providers.HuggingFaceProvider{},
-			wantModel:      "mistral-7b:mistral",
-			description:    "model with provider + provider option (ignored)",
-		},
-		{
-			name:           "request model takes precedence over provider",
-			clientModel:    "default-model",
-			clientProvider: providers.HuggingFaceProvider{},
-			reqModel:       testutils.Ptr("mistral-7b:mistral"),
-			optsProvider:   providers.HuggingFaceProvider{},
-			wantModel:      "mistral-7b:mistral",
-			description:    "request model with provider + request provider (model wins)",
-		},
-		{
-			name:           "applies request provider to request model without provider",
-			clientModel:    "default-model",
-			clientProvider: providers.HuggingFaceProvider{},
-			reqModel:       testutils.Ptr("mistral-7b"),
-			optsProvider:   providers.HuggingFaceProvider{},
-			wantModel:      "mistral-7b",
-			description:    "request model + request provider (overrides client)",
-		},
-		{
-			name:           "no provider applied when both missing",
+			name:           "happy path with model that already has provider",
 			clientModel:    "mistral-7b",
 			clientProvider: providers.HuggingFaceProvider{},
-			wantModel:      "mistral-7b",
-			description:    "model without provider, no provider option",
+			reqModel:       testutils.Ptr("mistral-7b:sambanova"),
+			wantModel:      "mistral-7b:sambanova",
+			description:    "model with existing provider is not modified",
 		},
 		{
-			name:           "client provider applied to request model when no request provider",
-			clientModel:    "default-model",
-			clientProvider: providers.HuggingFaceProvider{},
-			reqModel:       testutils.Ptr("mistral-7b"),
-			wantModel:      "mistral-7b",
-			description:    "client provider with request model",
-		},
-		{
-			name:           "model with multiple colons not modified by provider",
-			clientModel:    "org:model:variant",
-			clientProvider: providers.HuggingFaceProvider{},
-			wantModel:      "org:model:variant",
-			description:    "multiple colons in model",
-		},
-		{
-			name:           "optsModel_without_optsProvider_uses_clientProvider",
-			clientModel:    "default-model",
-			clientProvider: providers.HuggingFaceProvider{},
-			optsModel:      testutils.Ptr("opts-model"),
-			wantModel:      "opts-model",
-			description:    "opts model with client provider fallback",
-		},
-		{
-			name:           "both optsModel and optsProvider set override client defaults",
-			clientModel:    "client-model",
-			clientProvider: providers.HuggingFaceProvider{},
-			optsModel:      testutils.Ptr("opts-model"),
-			optsProvider:   providers.HuggingFaceProvider{},
-			wantModel:      "opts-model",
-			description:    "both request-level options override client defaults",
-		},
-		{
-			name:           "empty reqModel falls back to optsModel",
-			clientModel:    "default-model",
-			clientProvider: providers.HuggingFaceProvider{},
-			reqModel:       testutils.Ptr(""),
-			optsModel:      testutils.Ptr("opts-model"),
-			optsProvider:   providers.HuggingFaceProvider{},
-			wantModel:      "opts-model",
-			description:    "empty request model treated as nil for fallback",
-		},
-		{
-			name:           "model with trailing colon not modified by provider",
-			clientModel:    "model:",
-			clientProvider: providers.HuggingFaceProvider{},
-			wantModel:      "model:",
-			description:    "model with trailing colon treated as having provider",
-		},
-		{
-			name:           "use client provider when no options provider set",
+			name:           "error on nil provider",
 			clientModel:    "mistral-7b",
-			clientProvider: providers.HuggingFaceProvider{},
-			optsProvider:   nil,
-			wantModel:      "mistral-7b",
-			description:    "nil optsProvider uses client provider (HF, no suffix)",
-		},
-		{
-			name:           "override optsModel with empty, keep optsProvider",
-			clientModel:    "default-model",
-			clientProvider: providers.HuggingFaceProvider{},
-			optsProvider:   providers.HuggingFaceProvider{},
-			wantModel:      "default-model",
-			description:    "request provider override without model override uses client model",
-		},
-		{
-			name:           "override client provider with opts provider, no model override",
-			clientModel:    "mistral-7b",
-			clientProvider: providers.HuggingFaceProvider{},
-			optsProvider:   providers.HuggingFaceProvider{},
-			wantModel:      "mistral-7b",
-			description:    "request provider overrides client provider without model change",
+			clientProvider: nil,
+			wantErr:        true,
+			description:    "nil provider returns configuration error",
 		},
 	}
 
@@ -735,6 +630,11 @@ func TestChatService_ProviderFallback(t *testing.T) {
 		}
 
 		err := methodCall(&client, req, optsToPass)
+		if tc.wantErr {
+			require.Error(t, err, tc.description)
+
+			return
+		}
 		require.NoError(t, err)
 
 		require.NotNil(t, mt.LastRequest)
@@ -762,32 +662,34 @@ func TestChatService_ProviderFallback(t *testing.T) {
 				},
 			)
 
-			// Test CompleteStream method
-			sseBody := "data: {\"id\":\"id\",\"created\":1,\"model\":\"" + tc.wantModel + "\",\"system_fingerprint\":\"sig\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n" +
-				"data: [DONE]\n\n"
-			testImpl(t, tc,
-				func() *testutils.MockTransport {
-					mt := testutils.NewMockTransport(http.StatusOK, sseBody, nil)
-					mt.Response.Header.Set("Content-Type", "text/event-stream")
+			// Test CompleteStream method (skip for error cases)
+			if !tc.wantErr {
+				sseBody := "data: {\"id\":\"id\",\"created\":1,\"model\":\"" + tc.wantModel + "\",\"system_fingerprint\":\"sig\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n" +
+					"data: [DONE]\n\n"
+				testImpl(t, tc,
+					func() *testutils.MockTransport {
+						mt := testutils.NewMockTransport(http.StatusOK, sseBody, nil)
+						mt.Response.Header.Set("Content-Type", "text/event-stream")
 
-					return mt
-				},
-				func(client *Client, req ChatRequest, opts []Option) error {
-					stream, err := client.ChatStream(req, opts...)
-					if err != nil {
-						return err
-					}
-					defer func() { _ = stream.Close() }()
+						return mt
+					},
+					func(client *Client, req ChatRequest, opts []Option) error {
+						stream, err := client.ChatStream(req, opts...)
+						if err != nil {
+							return err
+						}
+						defer func() { _ = stream.Close() }()
 
-					chunk, err := stream.Recv(context.Background())
-					if err != nil {
-						return err
-					}
-					require.Equal(t, tc.wantModel, chunk.Model)
+						chunk, err := stream.Recv(context.Background())
+						if err != nil {
+							return err
+						}
+						require.Equal(t, tc.wantModel, chunk.Model)
 
-					return nil
-				},
-			)
+						return nil
+					},
+				)
+			}
 		})
 	}
 }

--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
+	"github.com/Kardbord/hfgo/v4/internal/providers"
 	"github.com/Kardbord/hfgo/v4/internal/request"
 	"github.com/Kardbord/hfgo/v4/internal/sdkversion"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
@@ -17,6 +18,18 @@ import (
 )
 
 const chatServiceResponseBody = `{"id":"id","created":1,"model":"m","system_fingerprint":"s","choices":[{"finish_reason":"stop","index":0,"message":{"role":"assistant","content":"hi"}}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`
+
+type mockProvider struct {
+	name string
+}
+
+func (p mockProvider) Endpoint(_, _ string) (string, error) {
+	return "", nil
+}
+
+func (p mockProvider) ProviderSuffix() string {
+	return p.name
+}
 
 func TestNewClient_Defaults(t *testing.T) {
 	t.Parallel()
@@ -26,7 +39,7 @@ func TestNewClient_Defaults(t *testing.T) {
 	require.Equal(t, request.DefaultBaseURL, client.opts.BaseURL)
 	require.Equal(t, request.DefaultToken, client.opts.Token)
 	require.Equal(t, request.DefaultModel, client.opts.Model)
-	require.Equal(t, request.DefaultProvider, client.opts.Provider)
+	require.Equal(t, providers.HuggingFaceProvider{}, client.opts.Provider)
 	require.Equal(t, request.DefaultMaxResponseBodyBytes, client.opts.MaxResponseBodyBytes)
 	require.Equal(t, sdkversion.UserAgent(), client.opts.UserAgent)
 	require.Nil(t, client.opts.Headers)
@@ -91,7 +104,7 @@ func TestChatService_Complete_ModelSelection(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NotNil(t, mt.LastRequest)
-			require.Equal(t, EndpointChatCompletion, mt.LastRequest.URL.Path)
+			require.Equal(t, "/v1/chat/completions", mt.LastRequest.URL.Path)
 
 			got := testutils.ReadRequestBody(t, mt)
 			require.Equal(t, tc.wantModel, got["model"])
@@ -349,70 +362,70 @@ func TestApplyProvider(t *testing.T) {
 	cases := []struct {
 		name        string
 		model       *string
-		provider    string
+		provider    Provider
 		wantModel   *string
 		description string
 	}{
 		{
 			name:        "applies provider to model without provider",
 			model:       testutils.Ptr("mistral-7b"),
-			provider:    "huggingface",
-			wantModel:   testutils.Ptr("mistral-7b:huggingface"),
+			provider:    providers.HuggingFaceProvider{},
+			wantModel:   testutils.Ptr("mistral-7b"),
 			description: "model + provider → model:provider",
 		},
 		{
 			name:        "ignores provider when model already has provider",
 			model:       testutils.Ptr("mistral-7b:mistral"),
-			provider:    "huggingface",
+			provider:    providers.HuggingFaceProvider{},
 			wantModel:   testutils.Ptr("mistral-7b:mistral"),
 			description: "model:provider + different provider → unchanged",
 		},
 		{
 			name:        "returns nil model when model is nil",
 			model:       nil,
-			provider:    "huggingface",
+			provider:    providers.HuggingFaceProvider{},
 			wantModel:   nil,
 			description: "nil model → nil",
 		},
 		{
 			name:        "returns nil model when model is empty string",
 			model:       testutils.Ptr(""),
-			provider:    "huggingface",
+			provider:    providers.HuggingFaceProvider{},
 			wantModel:   testutils.Ptr(""),
 			description: "empty model → empty",
 		},
 		{
 			name:        "returns model unchanged when provider is empty",
 			model:       testutils.Ptr("mistral-7b"),
-			provider:    "",
+			provider:    nil,
 			wantModel:   testutils.Ptr("mistral-7b"),
 			description: "model + empty provider → model unchanged",
 		},
 		{
 			name:        "handles provider with special characters",
 			model:       testutils.Ptr("mistral-7b"),
-			provider:    "provider-name",
+			provider:    mockProvider{name: "provider-name"},
 			wantModel:   testutils.Ptr("mistral-7b:provider-name"),
 			description: "provider with hyphens",
 		},
 		{
 			name:        "handles provider with underscores",
 			model:       testutils.Ptr("mistral-7b"),
-			provider:    "provider_name",
+			provider:    mockProvider{name: "provider_name"},
 			wantModel:   testutils.Ptr("mistral-7b:provider_name"),
 			description: "provider with underscores",
 		},
 		{
 			name:        "handles provider with dots",
 			model:       testutils.Ptr("mistral-7b"),
-			provider:    "provider.com",
+			provider:    mockProvider{name: "provider.com"},
 			wantModel:   testutils.Ptr("mistral-7b:provider.com"),
 			description: "provider with dots",
 		},
 		{
 			name:        "ignores provider when model has multiple colons",
 			model:       testutils.Ptr("org:model:variant"),
-			provider:    "huggingface",
+			provider:    providers.HuggingFaceProvider{},
 			wantModel:   testutils.Ptr("org:model:variant"),
 			description: "model with multiple colons",
 		},
@@ -440,9 +453,9 @@ func TestResolveModel(t *testing.T) {
 		name           string
 		reqModel       *string
 		clientModel    string
-		clientProvider string
+		clientProvider Provider
 		optsModel      string
-		optsProvider   string
+		optsProvider   Provider
 		wantModel      *string
 		description    string
 	}{
@@ -469,16 +482,16 @@ func TestResolveModel(t *testing.T) {
 		{
 			name:           "applies provider to resolved model",
 			clientModel:    "mistral-7b",
-			clientProvider: "huggingface",
-			wantModel:      testutils.Ptr("mistral-7b:huggingface"),
+			clientProvider: providers.HuggingFaceProvider{},
+			wantModel:      testutils.Ptr("mistral-7b"),
 			description:    "provider applied to client model",
 		},
 		{
 			name:           "applies options provider to request model",
 			reqModel:       testutils.Ptr("mistral-7b"),
 			clientModel:    "client-model",
-			clientProvider: "client-provider",
-			optsProvider:   "opts-provider",
+			clientProvider: mockProvider{name: "client-provider"},
+			optsProvider:   mockProvider{name: "opts-provider"},
 			wantModel:      testutils.Ptr("mistral-7b:opts-provider"),
 			description:    "options provider applied to request model",
 		},
@@ -486,7 +499,7 @@ func TestResolveModel(t *testing.T) {
 			name:         "request model with provider ignores provider option",
 			reqModel:     testutils.Ptr("mistral-7b:mistral"),
 			clientModel:  "client-model",
-			optsProvider: "huggingface",
+			optsProvider: providers.HuggingFaceProvider{},
 			wantModel:    testutils.Ptr("mistral-7b:mistral"),
 			description:  "existing provider in model not overridden",
 		},
@@ -494,8 +507,8 @@ func TestResolveModel(t *testing.T) {
 			name:           "empty request model falls back to options model",
 			reqModel:       testutils.Ptr(""),
 			optsModel:      "opts-model",
-			clientProvider: "client-provider",
-			optsProvider:   "opts-provider",
+			clientProvider: mockProvider{name: "client-provider"},
+			optsProvider:   mockProvider{name: "opts-provider"},
 			wantModel:      testutils.Ptr("opts-model:opts-provider"),
 			description:    "empty string treated as nil for fallback",
 		},
@@ -516,16 +529,12 @@ func TestResolveModel(t *testing.T) {
 				WithProvider(tc.clientProvider)
 
 			// For this test, we'll apply the options with the client defaults
-			var optsOverride request.Options
-			if tc.optsModel == "" && tc.optsProvider == "" {
-				// Use only client options
-				optsOverride = baseOpts
-			} else {
-				// Apply client defaults first, then override with opts
-				optsOverride = baseOpts.With(
-					WithModel(tc.optsModel),
-					WithProvider(tc.optsProvider),
-				)
+			optsOverride := baseOpts
+			if tc.optsModel != "" {
+				optsOverride = optsOverride.With(WithModel(tc.optsModel))
+			}
+			if tc.optsProvider != nil {
+				optsOverride = optsOverride.With(WithProvider(tc.optsProvider))
 			}
 
 			resolveModel(payload, optsOverride)
@@ -552,9 +561,9 @@ func TestChatService_ProviderFallback(t *testing.T) {
 	type TestCase struct {
 		name           string
 		clientModel    string
-		clientProvider string
+		clientProvider Provider
 		optsModel      *string
-		optsProvider   *string
+		optsProvider   Provider
 		reqModel       *string
 		wantModel      string
 		description    string
@@ -564,128 +573,129 @@ func TestChatService_ProviderFallback(t *testing.T) {
 		{
 			name:           "applies client provider to client model",
 			clientModel:    "mistral-7b",
-			clientProvider: "huggingface",
-			wantModel:      "mistral-7b:huggingface",
+			clientProvider: providers.HuggingFaceProvider{},
+			wantModel:      "mistral-7b",
 			description:    "client model + client provider",
 		},
 		{
 			name:         "applies request provider to request model",
 			clientModel:  "default-model",
 			reqModel:     testutils.Ptr("mistral-7b"),
-			optsProvider: testutils.Ptr("huggingface"),
-			wantModel:    "mistral-7b:huggingface",
+			optsProvider: providers.HuggingFaceProvider{},
+			wantModel:    "mistral-7b",
 			description:  "request model + request provider",
 		},
 		{
 			name:           "request provider overrides client provider",
 			clientModel:    "mistral-7b",
-			clientProvider: "mistral",
-			optsProvider:   testutils.Ptr("huggingface"),
-			wantModel:      "mistral-7b:huggingface",
+			clientProvider: mockProvider{name: "mistral"},
+			optsProvider:   providers.HuggingFaceProvider{},
+			wantModel:      "mistral-7b",
 			description:    "request provider overrides client provider",
 		},
 		{
 			name:           "ignores provider when model already has provider",
 			clientModel:    "mistral-7b:mistral",
-			clientProvider: "huggingface",
+			clientProvider: providers.HuggingFaceProvider{},
 			wantModel:      "mistral-7b:mistral",
 			description:    "model with provider + provider option (ignored)",
 		},
 		{
 			name:           "request model takes precedence over provider",
 			clientModel:    "default-model",
-			clientProvider: "huggingface",
+			clientProvider: providers.HuggingFaceProvider{},
 			reqModel:       testutils.Ptr("mistral-7b:mistral"),
-			optsProvider:   testutils.Ptr("huggingface"),
+			optsProvider:   providers.HuggingFaceProvider{},
 			wantModel:      "mistral-7b:mistral",
 			description:    "request model with provider + request provider (model wins)",
 		},
 		{
 			name:           "applies request provider to request model without provider",
 			clientModel:    "default-model",
-			clientProvider: "client-provider",
+			clientProvider: providers.HuggingFaceProvider{},
 			reqModel:       testutils.Ptr("mistral-7b"),
-			optsProvider:   testutils.Ptr("huggingface"),
-			wantModel:      "mistral-7b:huggingface",
+			optsProvider:   providers.HuggingFaceProvider{},
+			wantModel:      "mistral-7b",
 			description:    "request model + request provider (overrides client)",
 		},
 		{
-			name:        "no provider applied when both missing",
-			clientModel: "mistral-7b",
-			wantModel:   "mistral-7b",
-			description: "model without provider, no provider option",
+			name:           "no provider applied when both missing",
+			clientModel:    "mistral-7b",
+			clientProvider: providers.HuggingFaceProvider{},
+			wantModel:      "mistral-7b",
+			description:    "model without provider, no provider option",
 		},
 		{
 			name:           "client provider applied to request model when no request provider",
 			clientModel:    "default-model",
-			clientProvider: "client-provider",
+			clientProvider: providers.HuggingFaceProvider{},
 			reqModel:       testutils.Ptr("mistral-7b"),
-			wantModel:      "mistral-7b:client-provider",
+			wantModel:      "mistral-7b",
 			description:    "client provider with request model",
 		},
 		{
 			name:           "model with multiple colons not modified by provider",
 			clientModel:    "org:model:variant",
-			clientProvider: "huggingface",
+			clientProvider: providers.HuggingFaceProvider{},
 			wantModel:      "org:model:variant",
 			description:    "multiple colons in model",
 		},
 		{
-			name:           "optsModel without optsProvider uses clientProvider",
+			name:           "optsModel_without_optsProvider_uses_clientProvider",
 			clientModel:    "default-model",
-			clientProvider: "client-provider",
+			clientProvider: providers.HuggingFaceProvider{},
 			optsModel:      testutils.Ptr("opts-model"),
-			wantModel:      "opts-model:client-provider",
+			wantModel:      "opts-model",
 			description:    "opts model with client provider fallback",
 		},
 		{
 			name:           "both optsModel and optsProvider set override client defaults",
 			clientModel:    "client-model",
-			clientProvider: "client-provider",
+			clientProvider: providers.HuggingFaceProvider{},
 			optsModel:      testutils.Ptr("opts-model"),
-			optsProvider:   testutils.Ptr("opts-provider"),
-			wantModel:      "opts-model:opts-provider",
+			optsProvider:   providers.HuggingFaceProvider{},
+			wantModel:      "opts-model",
 			description:    "both request-level options override client defaults",
 		},
 		{
 			name:           "empty reqModel falls back to optsModel",
 			clientModel:    "default-model",
-			clientProvider: "client-provider",
+			clientProvider: providers.HuggingFaceProvider{},
 			reqModel:       testutils.Ptr(""),
 			optsModel:      testutils.Ptr("opts-model"),
-			optsProvider:   testutils.Ptr("opts-provider"),
-			wantModel:      "opts-model:opts-provider",
+			optsProvider:   providers.HuggingFaceProvider{},
+			wantModel:      "opts-model",
 			description:    "empty request model treated as nil for fallback",
 		},
 		{
 			name:           "model with trailing colon not modified by provider",
 			clientModel:    "model:",
-			clientProvider: "provider",
+			clientProvider: providers.HuggingFaceProvider{},
 			wantModel:      "model:",
 			description:    "model with trailing colon treated as having provider",
 		},
 		{
-			name:           "override client provider with empty provider",
+			name:           "use client provider when no options provider set",
 			clientModel:    "mistral-7b",
-			clientProvider: "huggingface",
-			optsProvider:   testutils.Ptr(""),
+			clientProvider: providers.HuggingFaceProvider{},
+			optsProvider:   nil,
 			wantModel:      "mistral-7b",
-			description:    "explicitly passing empty provider removes provider",
+			description:    "nil optsProvider uses client provider (HF, no suffix)",
 		},
 		{
 			name:           "override optsModel with empty, keep optsProvider",
 			clientModel:    "default-model",
-			clientProvider: "client-provider",
-			optsProvider:   testutils.Ptr("opts-provider"),
-			wantModel:      "default-model:opts-provider",
+			clientProvider: providers.HuggingFaceProvider{},
+			optsProvider:   providers.HuggingFaceProvider{},
+			wantModel:      "default-model",
 			description:    "request provider override without model override uses client model",
 		},
 		{
 			name:           "override client provider with opts provider, no model override",
 			clientModel:    "mistral-7b",
-			clientProvider: "huggingface",
-			optsProvider:   testutils.Ptr("mistral"),
-			wantModel:      "mistral-7b:mistral",
+			clientProvider: providers.HuggingFaceProvider{},
+			optsProvider:   providers.HuggingFaceProvider{},
+			wantModel:      "mistral-7b",
 			description:    "request provider overrides client provider without model change",
 		},
 	}
@@ -721,14 +731,14 @@ func TestChatService_ProviderFallback(t *testing.T) {
 			optsToPass = append(optsToPass, WithModel(*tc.optsModel))
 		}
 		if tc.optsProvider != nil {
-			optsToPass = append(optsToPass, WithProvider(*tc.optsProvider))
+			optsToPass = append(optsToPass, WithProvider(tc.optsProvider))
 		}
 
 		err := methodCall(&client, req, optsToPass)
 		require.NoError(t, err)
 
 		require.NotNil(t, mt.LastRequest)
-		require.Equal(t, EndpointChatCompletion, mt.LastRequest.URL.Path)
+		require.Equal(t, "/v1/chat/completions", mt.LastRequest.URL.Path)
 
 		got := testutils.ReadRequestBody(t, mt)
 		require.Equal(t, tc.wantModel, got["model"], tc.description)

--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -429,6 +429,13 @@ func TestApplyProvider(t *testing.T) {
 			wantModel:   testutils.Ptr("org:model:variant"),
 			description: "model with multiple colons",
 		},
+		{
+			name:        "ignores non-hf provider when model has multiple colons",
+			model:       testutils.Ptr("org:model:variant"),
+			provider:    mockProvider{name: "sambanova"},
+			wantModel:   testutils.Ptr("org:model:variant"),
+			description: "non-HF provider ignored for multi-colon model",
+		},
 	}
 
 	for _, tc := range cases {

--- a/client.go
+++ b/client.go
@@ -44,14 +44,16 @@ func NewClient(opts ...Option) Client {
 //  3. Client-level Model option
 //
 // Provider Precedence:
-// The Provider field is applied as a fallback only if the resolved Model does not
-// already contain a provider (indicated by ":" in the model string). If the Model
-// is in the format "model:provider", the Provider option is ignored.
+// The Provider option is used as a suffix appended to the model string for
+// routing in OpenAI-compatible endpoints. If the Model is in the format
+// "model:provider", the Provider option is ignored. When the provider is
+// the default HuggingFace provider, no suffix is appended and the router
+// selects a provider automatically.
 //
 // For example:
-//   - Model="mistral-7b", Provider="huggingface" → "mistral-7b:huggingface"
-//   - Model="mistral-7b:huggingface", Provider="mistral" → "mistral-7b:huggingface" (Provider ignored)
-//   - Model="mistral-7b:huggingface", Provider="" → "mistral-7b:huggingface"
+//   - Model="mistral-7b", Provider=HuggingFaceProvider → "mistral-7b"
+//   - Model="mistral-7b", Provider=mockProvider("sambanova") → "mistral-7b:sambanova"
+//   - Model="mistral-7b:sambanova", Provider=HuggingFaceProvider → "mistral-7b:sambanova" (Provider ignored)
 //
 // Behavior:
 //   - Returns a configuration error if the request is missing a model or messages.
@@ -85,14 +87,16 @@ func (c Client) Chat(req ChatRequest, opts ...Option) (ChatResponse, error) {
 //  3. Client-level Model option
 //
 // Provider Precedence:
-// The Provider field is applied as a fallback only if the resolved Model does not
-// already contain a provider (indicated by ":" in the model string). If the Model
-// is in the format "model:provider", the Provider option is ignored.
+// The Provider option is used as a suffix appended to the model string for
+// routing in OpenAI-compatible endpoints. If the Model is in the format
+// "model:provider", the Provider option is ignored. When the provider is
+// the default HuggingFace provider, no suffix is appended and the router
+// selects a provider automatically.
 //
 // For example:
-//   - Model="mistral-7b", Provider="huggingface" → "mistral-7b:huggingface"
-//   - Model="mistral-7b:huggingface", Provider="mistral" → "mistral-7b:huggingface" (Provider ignored)
-//   - Model="mistral-7b:huggingface", Provider="" → "mistral-7b:huggingface"
+//   - Model="mistral-7b", Provider=HuggingFaceProvider → "mistral-7b"
+//   - Model="mistral-7b", Provider=mockProvider("sambanova") → "mistral-7b:sambanova"
+//   - Model="mistral-7b:sambanova", Provider=HuggingFaceProvider → "mistral-7b:sambanova" (Provider ignored)
 //
 // Behavior:
 //   - Returns a configuration error if the request is missing a model or messages.
@@ -107,8 +111,6 @@ func (c Client) ChatStream(req ChatRequest, opts ...Option) (*ChatStream, error)
 // classification response for a single input.
 //
 // For multiple classification inputs, use ClassifyTextBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) ClassifyText(
 	req TextClassificationRequest,
 	opts ...Option,
@@ -123,8 +125,6 @@ func (c Client) ClassifyText(
 // officially documented; behavior may change without notice.
 //
 // Callers should check the length of the response list before indexing.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) ClassifyTextBatch(
 	req TextClassificationBatchRequest,
 	opts ...Option,
@@ -136,8 +136,6 @@ func (c Client) ClassifyTextBatch(
 // classification response for a single input.
 //
 // For multiple inputs, use ClassifyTokensBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) ClassifyTokens(
 	req TokenClassificationRequest,
 	opts ...Option,
@@ -152,8 +150,6 @@ func (c Client) ClassifyTokens(
 // officially documented; behavior may change without notice.
 //
 // Callers should check the length of the response list before indexing.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) ClassifyTokensBatch(
 	req TokenClassificationBatchRequest,
 	opts ...Option,
@@ -165,8 +161,6 @@ func (c Client) ClassifyTokensBatch(
 //
 // The request must include both a question and a context. The model will
 // identify the answer to the question within the provided context.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) AnswerQuestion(
 	req QuestionAnsweringRequest,
 	opts ...Option,
@@ -178,8 +172,6 @@ func (c Client) AnswerQuestion(
 // returns the zero-shot text classification response for a single input.
 //
 // For multiple inputs, use ZeroShotClassifyTextBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) ZeroShotClassifyText(
 	req ZeroShotTextClassificationRequest,
 	opts ...Option,
@@ -195,8 +187,6 @@ func (c Client) ZeroShotClassifyText(
 // officially documented; behavior may change without notice.
 //
 // Callers should check the length of the response list before indexing.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) ZeroShotClassifyTextBatch(
 	req ZeroShotTextClassificationBatchRequest,
 	opts ...Option,
@@ -208,8 +198,6 @@ func (c Client) ZeroShotClassifyTextBatch(
 // for a single input.
 //
 // For multiple inputs, use FillMaskBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) FillMask(req FillMaskRequest, opts ...Option) ([]FillMaskPrediction, error) {
 	return newFillMaskService(c.opts).fill(req, opts...)
 }
@@ -221,8 +209,6 @@ func (c Client) FillMask(req FillMaskRequest, opts ...Option) ([]FillMaskPredict
 // officially documented; behavior may change without notice.
 //
 // Callers should check the length of the response list before indexing.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) FillMaskBatch(
 	req FillMaskBatchRequest,
 	opts ...Option,
@@ -237,8 +223,6 @@ func (c Client) FillMaskBatch(
 // one-element list rather than a bare summary object.
 //
 // For multiple inputs, use SummarizeBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) Summarize(req SummarizationRequest, opts ...Option) ([]Summarization, error) {
 	return newSummarizationService(c.opts).summarize(req, opts...)
 }
@@ -251,8 +235,6 @@ func (c Client) Summarize(req SummarizationRequest, opts ...Option) ([]Summariza
 // officially documented; behavior may change without notice. The response is
 // a flat list (one summary per input) — not a nested list — consistent with
 // how the API returns a list even for a single input.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) SummarizeBatch(
 	req SummarizationBatchRequest,
 	opts ...Option,
@@ -269,8 +251,6 @@ func (c Client) SummarizeBatch(
 // answering, not an array — despite the upstream schema declaring an array
 // response. This method returns a single TableQuestionAnswer to match the
 // actual API behavior.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) AnswerTableQuestion(
 	req TableQuestionAnsweringRequest,
 	opts ...Option,
@@ -285,8 +265,6 @@ func (c Client) AnswerTableQuestion(
 // one-element list rather than a bare translation object.
 //
 // For multiple inputs, use TranslateBatch.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) Translate(req TranslationRequest, opts ...Option) ([]Translation, error) {
 	return newTranslationService(c.opts).translate(req, opts...)
 }
@@ -299,8 +277,6 @@ func (c Client) Translate(req TranslationRequest, opts ...Option) ([]Translation
 // officially documented; behavior may change without notice. The response is
 // a flat list (one translation per input) — not a nested list — consistent with
 // how the API returns a list even for a single input.
-//
-// The Provider option is ignored for now, as hf-inference is currently the only supported provider.
 func (c Client) TranslateBatch(
 	req TranslationBatchRequest,
 	opts ...Option,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,7 +175,7 @@ response, err := client.Chat(
 - `WithBaseURL(url string)`: Base URL for API requests (no query params/fragments)
 - `WithToken(token string)`: Bearer authentication token
 - `WithModel(model string)`: Model identifier for requests
-- `WithProvider(provider string)`: Inference provider
+- `WithProvider(provider Provider)`: Inference provider
 
 ### HTTP & Transport
 - `WithHTTPClientFactory(factory func() http.Client)`: Factory for HTTP clients
@@ -320,7 +320,7 @@ The Model field is resolved with the following precedence (highest to lowest):
 2. Per-request options Model override
 3. Client-level Model option
 
-The Provider field is applied as a fallback only if the resolved Model does not already contain a provider (indicated by ":" in the model string). If the Model is in the format "model:provider", the Provider option is ignored.
+The Provider field is applied as a suffix to the model string for routing in OpenAI-compatible endpoints. If the Model is in the format "model:provider", the Provider option is ignored. When the provider is the default HuggingFace provider, no suffix is appended and the router selects a provider automatically.
 
 **Behavior**:
 - Returns `SDKError` (kind: Configuration) if the request is missing a model or messages (zero-value request)
@@ -543,7 +543,6 @@ Same as `StreamRaw`, but streams the request body from an `io.Reader`.
 ## Endpoints
 
 ### Chat Completions
-- **Constant**: `EndpointChatCompletion = "/v1/chat/completions"`
 - **Method**: POST
 - **Methods**: `Client.Chat(...)` or `Client.ChatStream(...)`
 

--- a/feature_extraction_service.go
+++ b/feature_extraction_service.go
@@ -21,7 +21,7 @@ func (s featureExtractionService) extract(
 ) (FeatureExtraction, error) {
 	return doModelInference[FeatureExtractionRequest, FeatureExtraction](
 		s.opts.With(opts...),
-		"feature extraction",
+		TaskFeatureExtraction,
 		req,
 	)
 }
@@ -33,7 +33,7 @@ func (s featureExtractionService) extractBatch(
 ) ([]FeatureExtraction, error) {
 	return doModelInference[FeatureExtractionBatchRequest, []FeatureExtraction](
 		s.opts.With(opts...),
-		"feature extraction",
+		TaskFeatureExtraction,
 		req,
 	)
 }

--- a/fill_mask_service.go
+++ b/fill_mask_service.go
@@ -21,7 +21,7 @@ func (s fillMaskService) fill(
 ) ([]FillMaskPrediction, error) {
 	return doModelInference[FillMaskRequest, []FillMaskPrediction](
 		s.opts.With(opts...),
-		"fill mask",
+		TaskFillMask,
 		req,
 	)
 }
@@ -33,7 +33,7 @@ func (s fillMaskService) fillBatch(
 ) ([][]FillMaskPrediction, error) {
 	return doModelInference[FillMaskBatchRequest, [][]FillMaskPrediction](
 		s.opts.With(opts...),
-		"fill mask",
+		TaskFillMask,
 		req,
 	)
 }

--- a/internal/providers/huggingface.go
+++ b/internal/providers/huggingface.go
@@ -1,0 +1,34 @@
+package providers
+
+import "errors"
+
+// HuggingFaceProvider implements Provider for the HuggingFace inference API.
+type HuggingFaceProvider struct{}
+
+// ProviderSuffix returns the provider suffix appended to model IDs
+// for routing in OpenAI-compatible endpoints.
+func (p HuggingFaceProvider) ProviderSuffix() string {
+	return ""
+}
+
+// Endpoint returns the API endpoint path for the given task and model.
+// It returns an error if model is empty.
+//
+// The endpoint depends on the task: pipeline tasks (e.g. "feature-extraction",
+// "sentence-similarity") return a task-specific path, "chat-completion" returns
+// the OpenAI-compatible chat completions path, and all other tasks return the
+// default model path.
+func (p HuggingFaceProvider) Endpoint(task, model string) (string, error) {
+	if model == "" {
+		return "", errors.New("model is required")
+	}
+
+	switch task {
+	case "feature-extraction", "sentence-similarity":
+		return "hf-inference/models/" + model + "/pipeline/" + task, nil
+	case "chat-completion":
+		return "/v1/chat/completions", nil
+	default:
+		return "hf-inference/models/" + model, nil
+	}
+}

--- a/internal/providers/huggingface.go
+++ b/internal/providers/huggingface.go
@@ -14,13 +14,13 @@ func (p HuggingFaceProvider) ProviderSuffix() string {
 }
 
 // Endpoint returns the API endpoint path for the given task and model.
-// It returns an error if model is empty.
+// It returns an error if model is empty or the task is unsupported.
 //
-// The endpoint depends on the task: pipeline tasks (e.g. "feature-extraction",
-// "sentence-similarity") return a task-specific path, "chat-completion" returns
+// The endpoint depends on the task: pipeline tasks (e.g. feature-extraction,
+// sentence-similarity) return a task-specific path, chat-completion returns
 // the OpenAI-compatible chat completions path, and all other tasks return the
 // default model path.
-func (p HuggingFaceProvider) Endpoint(task, model string) (string, error) {
+func (p HuggingFaceProvider) Endpoint(task Task, model string) (string, error) {
 	if model == "" {
 		return "", &hferrors.SDKError{
 			Kind:    hferrors.SDKErrorKindConfiguration,
@@ -30,11 +30,19 @@ func (p HuggingFaceProvider) Endpoint(task, model string) (string, error) {
 	}
 
 	switch task {
-	case "feature-extraction", "sentence-similarity":
-		return "hf-inference/models/" + model + "/pipeline/" + task, nil
-	case "chat-completion":
+	case TaskFeatureExtraction, TaskSentenceSimilarity:
+		return "hf-inference/models/" + model + "/pipeline/" + string(task), nil
+	case TaskChatCompletion:
 		return "v1/chat/completions", nil
-	default:
+	case TaskTextClassification, TaskZeroShotTextClassification, TaskTokenClassification,
+		TaskQuestionAnswering, TaskTableQuestionAnswering, TaskFillMask,
+		TaskSummarization, TaskTranslation:
 		return "hf-inference/models/" + model, nil
+	default:
+		return "", &hferrors.SDKError{
+			Kind:    hferrors.SDKErrorKindConfiguration,
+			Message: "unsupported task " + string(task),
+			Err:     nil,
+		}
 	}
 }

--- a/internal/providers/huggingface.go
+++ b/internal/providers/huggingface.go
@@ -1,6 +1,8 @@
 package providers
 
-import "errors"
+import (
+	"github.com/Kardbord/hfgo/v4/internal/hferrors"
+)
 
 // HuggingFaceProvider implements Provider for the HuggingFace inference API.
 type HuggingFaceProvider struct{}
@@ -20,14 +22,18 @@ func (p HuggingFaceProvider) ProviderSuffix() string {
 // default model path.
 func (p HuggingFaceProvider) Endpoint(task, model string) (string, error) {
 	if model == "" {
-		return "", errors.New("model is required")
+		return "", &hferrors.SDKError{
+			Kind:    hferrors.SDKErrorKindConfiguration,
+			Message: "model is required",
+			Err:     nil,
+		}
 	}
 
 	switch task {
 	case "feature-extraction", "sentence-similarity":
 		return "hf-inference/models/" + model + "/pipeline/" + task, nil
 	case "chat-completion":
-		return "/v1/chat/completions", nil
+		return "v1/chat/completions", nil
 	default:
 		return "hf-inference/models/" + model, nil
 	}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -1,0 +1,13 @@
+// Package providers defines the Provider interface and built-in provider implementations.
+package providers
+
+// Provider knows how to construct API endpoints for a given task and model.
+type Provider interface {
+	// Endpoint returns the API endpoint path for the given task and model.
+	// It returns an error if the endpoint cannot be constructed.
+	Endpoint(task, model string) (string, error)
+
+	// ProviderSuffix returns the provider suffix appended to model IDs
+	// for routing in OpenAI-compatible endpoints.
+	ProviderSuffix() string
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -2,12 +2,13 @@
 package providers
 
 // Provider knows how to construct API endpoints for a given task and model.
+// Implementations must be safe for concurrent use.
 type Provider interface {
 	// Endpoint returns the API endpoint path for the given task and model.
-	// It returns an error if the endpoint cannot be constructed.
+	// It returns an error if the model is invalid or the task is unsupported.
 	Endpoint(task, model string) (string, error)
-
 	// ProviderSuffix returns the provider suffix appended to model IDs
-	// for routing in OpenAI-compatible endpoints.
+	// for routing in OpenAI-compatible endpoints. An empty string means
+	// no suffix is appended (e.g. for the default HuggingFace provider).
 	ProviderSuffix() string
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -6,7 +6,7 @@ package providers
 type Provider interface {
 	// Endpoint returns the API endpoint path for the given task and model.
 	// It returns an error if the model is invalid or the task is unsupported.
-	Endpoint(task, model string) (string, error)
+	Endpoint(task Task, model string) (string, error)
 	// ProviderSuffix returns the provider suffix appended to model IDs
 	// for routing in OpenAI-compatible endpoints. An empty string means
 	// no suffix is appended (e.g. for the default HuggingFace provider).

--- a/internal/providers/provider_fuzz_test.go
+++ b/internal/providers/provider_fuzz_test.go
@@ -1,0 +1,32 @@
+//go:build !integration
+
+package providers
+
+import (
+	"testing"
+)
+
+func FuzzHuggingFaceProviderEndpoint(f *testing.F) {
+	p := HuggingFaceProvider{}
+
+	f.Add("chat-completion", "mistral-7b")
+	f.Add("feature-extraction", "bert-base")
+	f.Add("sentence-similarity", "sentence-transformers/all-MiniLM-L6-v2")
+	f.Add("text-classification", "distilbert-base-uncased")
+	f.Add("", "")
+	f.Add("chat-completion", "")
+	f.Add("", "mistral-7b")
+	f.Add("unknown-task", "model")
+	f.Add("feature-extraction", "model:provider")
+	f.Add("chat-completion", "org/model:variant")
+
+	f.Fuzz(func(t *testing.T, task, model string) {
+		ep, err := p.Endpoint(task, model)
+		if model == "" && err == nil {
+			t.Errorf("expected error for empty model, got %q", ep)
+		}
+		if model != "" && err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/providers/provider_fuzz_test.go
+++ b/internal/providers/provider_fuzz_test.go
@@ -9,24 +9,25 @@ import (
 func FuzzHuggingFaceProviderEndpoint(f *testing.F) {
 	p := HuggingFaceProvider{}
 
-	f.Add("chat-completion", "mistral-7b")
-	f.Add("feature-extraction", "bert-base")
-	f.Add("sentence-similarity", "sentence-transformers/all-MiniLM-L6-v2")
-	f.Add("text-classification", "distilbert-base-uncased")
+	f.Add(string(TaskChatCompletion), "mistral-7b")
+	f.Add(string(TaskFeatureExtraction), "bert-base")
+	f.Add(string(TaskSentenceSimilarity), "sentence-transformers/all-MiniLM-L6-v2")
+	f.Add(string(TaskTextClassification), "distilbert-base-uncased")
 	f.Add("", "")
-	f.Add("chat-completion", "")
+	f.Add(string(TaskChatCompletion), "")
 	f.Add("", "mistral-7b")
 	f.Add("unknown-task", "model")
-	f.Add("feature-extraction", "model:provider")
-	f.Add("chat-completion", "org/model:variant")
+	f.Add(string(TaskFeatureExtraction), "model:provider")
+	f.Add(string(TaskChatCompletion), "org/model:variant")
 
 	f.Fuzz(func(t *testing.T, task, model string) {
-		ep, err := p.Endpoint(task, model)
+		ep, err := p.Endpoint(Task(task), model)
 		if model == "" && err == nil {
 			t.Errorf("expected error for empty model, got %q", ep)
 		}
 		if model != "" && err != nil {
-			t.Errorf("unexpected error: %v", err)
+			// Unknown tasks now return an error; only known tasks succeed.
+			_ = ep
 		}
 	})
 }

--- a/internal/providers/provider_fuzz_test.go
+++ b/internal/providers/provider_fuzz_test.go
@@ -25,9 +25,8 @@ func FuzzHuggingFaceProviderEndpoint(f *testing.F) {
 		if model == "" && err == nil {
 			t.Errorf("expected error for empty model, got %q", ep)
 		}
-		if model != "" && err != nil {
-			// Unknown tasks now return an error; only known tasks succeed.
-			_ = ep
+		if task == "" && err == nil {
+			t.Errorf("expected error for empty task, got %q", ep)
 		}
 	})
 }

--- a/internal/providers/task.go
+++ b/internal/providers/task.go
@@ -1,0 +1,29 @@
+package providers
+
+// Task identifies an inference task type.
+type Task string
+
+const (
+	// TaskTextClassification is the text classification task.
+	TaskTextClassification Task = "text-classification"
+	// TaskZeroShotTextClassification is the zero-shot text classification task.
+	TaskZeroShotTextClassification Task = "zero-shot-text-classification"
+	// TaskTokenClassification is the token classification task.
+	TaskTokenClassification Task = "token-classification"
+	// TaskQuestionAnswering is the question answering task.
+	TaskQuestionAnswering Task = "question-answering"
+	// TaskTableQuestionAnswering is the table question answering task.
+	TaskTableQuestionAnswering Task = "table-question-answering"
+	// TaskFillMask is the fill mask task.
+	TaskFillMask Task = "fill-mask"
+	// TaskSummarization is the summarization task.
+	TaskSummarization Task = "summarization"
+	// TaskTranslation is the translation task.
+	TaskTranslation Task = "translation"
+	// TaskFeatureExtraction is the feature extraction task.
+	TaskFeatureExtraction Task = "feature-extraction"
+	// TaskSentenceSimilarity is the sentence similarity task.
+	TaskSentenceSimilarity Task = "sentence-similarity"
+	// TaskChatCompletion is the chat completion task.
+	TaskChatCompletion Task = "chat-completion"
+)

--- a/internal/request/options.go
+++ b/internal/request/options.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
+	"github.com/Kardbord/hfgo/v4/internal/providers"
 	"github.com/Kardbord/hfgo/v4/internal/sdkversion"
 )
 
@@ -20,7 +21,7 @@ type Options struct {
 	BaseURL              string
 	Token                string
 	Model                string
-	Provider             string
+	Provider             providers.Provider
 	UserAgent            string
 	Headers              http.Header
 	MaxResponseBodyBytes int64
@@ -34,8 +35,6 @@ const (
 	DefaultToken = ""
 	// DefaultModel is the default model to use.
 	DefaultModel = ""
-	// DefaultProvider is the default inference provider.
-	DefaultProvider = ""
 	// DefaultMaxResponseBodyBytes caps the amount of response data read into memory by default.
 	DefaultMaxResponseBodyBytes int64 = 1 << 20 // 1 MiB
 )
@@ -68,7 +67,7 @@ func NewOptions() Options {
 		BaseURL:              DefaultBaseURL,
 		Token:                DefaultToken,
 		Model:                DefaultModel,
-		Provider:             DefaultProvider,
+		Provider:             providers.HuggingFaceProvider{},
 		UserAgent:            sdkversion.UserAgent(),
 		Headers:              nil,
 		MaxResponseBodyBytes: DefaultMaxResponseBodyBytes,
@@ -152,9 +151,18 @@ func (o Options) WithModel(m string) Options {
 }
 
 // WithProvider returns a new Options instance with the provider updated.
-func (o Options) WithProvider(p string) Options {
+func (o Options) WithProvider(p providers.Provider) Options {
 	o = o.clone()
 	o.Provider = p
+
+	return o
+}
+
+// WithDefaultProvider returns a new Options instance with the default
+// HuggingFace provider.
+func (o Options) WithDefaultProvider() Options {
+	o = o.clone()
+	o.Provider = providers.HuggingFaceProvider{}
 
 	return o
 }
@@ -288,9 +296,17 @@ func WithModel(m string) Option {
 }
 
 // WithProvider returns an Option that sets the provider for API requests.
-func WithProvider(p string) Option {
+func WithProvider(p providers.Provider) Option {
 	return func(o *Options) {
 		o.Provider = p
+	}
+}
+
+// WithDefaultProvider returns an Option that sets the provider to the default
+// HuggingFace provider.
+func WithDefaultProvider() Option {
+	return func(o *Options) {
+		o.Provider = providers.HuggingFaceProvider{}
 	}
 }
 

--- a/internal/request/options.go
+++ b/internal/request/options.go
@@ -112,6 +112,13 @@ func (o Options) Validate() error {
 			Err:     nil,
 		}
 	}
+	if o.Provider == nil {
+		return &hferrors.SDKError{
+			Kind:    hferrors.SDKErrorKindConfiguration,
+			Message: "provider must not be nil",
+			Err:     nil,
+		}
+	}
 
 	return nil
 }

--- a/internal/request/options_test.go
+++ b/internal/request/options_test.go
@@ -560,6 +560,12 @@ func TestOptions_Validate(t *testing.T) {
 			wantErr: true,
 			kind:    hferrors.SDKErrorKindConfiguration,
 		},
+		{
+			name:    "nil provider",
+			opts:    NewOptions().WithProvider(nil),
+			wantErr: true,
+			kind:    hferrors.SDKErrorKindConfiguration,
+		},
 	}
 
 	for i := range tests {

--- a/internal/request/options_test.go
+++ b/internal/request/options_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Kardbord/hfgo/v4/internal/hferrors"
+	"github.com/Kardbord/hfgo/v4/internal/providers"
 	"github.com/Kardbord/hfgo/v4/internal/sdkversion"
 	"github.com/Kardbord/hfgo/v4/internal/testutils"
 )
@@ -58,7 +59,7 @@ func TestOptions_With(t *testing.T) {
 			options: []Option{
 				WithToken("token123"),
 				WithModel("llama-3"),
-				WithProvider("aws"),
+				WithProvider(providers.HuggingFaceProvider{}),
 				WithUserAgent("myapp/1.2.3"),
 			},
 			validate: func(t *testing.T, _ Options, updated Options) {
@@ -69,8 +70,9 @@ func TestOptions_With(t *testing.T) {
 				if updated.Model != "llama-3" {
 					t.Errorf("expected Model 'llama-3', got %q", updated.Model)
 				}
-				if updated.Provider != "aws" {
-					t.Errorf("expected Provider 'aws', got %q", updated.Provider)
+				defaultProvider := providers.HuggingFaceProvider{}
+				if updated.Provider != defaultProvider {
+					t.Errorf("expected Provider %v, got %v", defaultProvider, updated.Provider)
 				}
 				if updated.UserAgent != "myapp/1.2.3" {
 					t.Errorf("expected UserAgent 'myapp/1.2.3, got %q", updated.UserAgent)
@@ -178,7 +180,7 @@ func TestOptions_WithHelpers(t *testing.T) {
 		WithBaseURL("https://example.com").
 		WithToken("token").
 		WithModel("model").
-		WithProvider("provider").
+		WithProvider(providers.HuggingFaceProvider{}).
 		WithContext(ctx).
 		WithDefaultHTTPClient().
 		WithMaxResponseBodyBytes(42).
@@ -195,8 +197,9 @@ func TestOptions_WithHelpers(t *testing.T) {
 	if opts.Model != "model" {
 		t.Errorf("expected Model to be set, got %q", opts.Model)
 	}
-	if opts.Provider != "provider" {
-		t.Errorf("expected Provider to be set, got %q", opts.Provider)
+	defaultProvider := providers.HuggingFaceProvider{}
+	if opts.Provider != defaultProvider {
+		t.Errorf("expected Provider %v, got %v", defaultProvider, opts.Provider)
 	}
 	if opts.Context() != ctx {
 		t.Error("expected context to be set")
@@ -286,7 +289,7 @@ func TestOptions_DefensiveHeaderClone(t *testing.T) {
 		{
 			name: "WithProvider",
 			apply: func(opts Options) Options {
-				return opts.WithProvider("provider")
+				return opts.WithProvider(providers.HuggingFaceProvider{})
 			},
 		},
 		{
@@ -440,8 +443,8 @@ func TestNewOptions(t *testing.T) {
 			name: "has default Provider",
 			validate: func(t *testing.T, opts Options) {
 				t.Helper()
-				if opts.Provider != DefaultProvider {
-					t.Errorf("expected Provider %q, got %q", DefaultProvider, opts.Provider)
+				if opts.Provider == nil {
+					t.Errorf("expected Provider not nil, got nil")
 				}
 			},
 		},

--- a/internal/request/options_test.go
+++ b/internal/request/options_test.go
@@ -293,6 +293,12 @@ func TestOptions_DefensiveHeaderClone(t *testing.T) {
 			},
 		},
 		{
+			name: "WithDefaultProvider",
+			apply: func(opts Options) Options {
+				return opts.WithDefaultProvider()
+			},
+		},
+		{
 			name: "WithUserAgent",
 			apply: func(opts Options) Options {
 				return opts.WithUserAgent("ua/1.0")

--- a/model_request.go
+++ b/model_request.go
@@ -25,10 +25,23 @@ func doModelInference[Req, Resp any](opts request.Options, task string, req Req)
 		}
 	}
 
+	if opts.Provider == nil {
+		return zero, &SDKError{
+			Kind:    SDKErrorKindConfiguration,
+			Message: "provider must not be nil",
+			Err:     nil,
+		}
+	}
+
+	endpoint, err := opts.Provider.Endpoint(task, opts.Model)
+	if err != nil {
+		return zero, err
+	}
+
 	return request.DoJSON[Req, Resp](
 		opts,
 		http.MethodPost,
-		"hf-inference/models/"+opts.Model,
+		endpoint,
 		req,
 	)
 }

--- a/model_request.go
+++ b/model_request.go
@@ -9,18 +9,22 @@ import (
 // doModelInference posts req to the inference model endpoint for the model
 // configured in opts, returning the typed response. It returns a configuration
 // SDK error when no model is set. task names the inference task in that error
-// message, e.g. "fill mask" or "summarization".
+// message, e.g. "text-classification" or "summarization".
 //
 // It is intended for pointer or slice response types: on the configuration
 // error path it returns the typed zero value of Resp, which is nil for slices
 // and pointers and so also signals "no result" to callers.
-func doModelInference[Req, Resp any](opts request.Options, task string, req Req) (Resp, error) {
+func doModelInference[Req, Resp any](
+	opts request.Options,
+	task Task,
+	req Req,
+) (Resp, error) {
 	var zero Resp
 
 	if opts.Model == "" {
 		return zero, &SDKError{
 			Kind:    SDKErrorKindConfiguration,
-			Message: "the model option must be set for " + task + " to succeed",
+			Message: "the model option must be set for " + string(task) + " to succeed",
 			Err:     nil,
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -28,8 +28,14 @@ func WithModel(m string) Option {
 
 // WithProvider returns an Option that sets the provider for API requests.
 // The provider specifies which inference provider should handle the request.
-func WithProvider(p string) Option {
+func WithProvider(p Provider) Option {
 	return request.WithProvider(p)
+}
+
+// WithDefaultProvider returns an Option that sets the provider to the default
+// HuggingFace provider.
+func WithDefaultProvider() Option {
+	return request.WithDefaultProvider()
 }
 
 // WithHTTPClientFactory returns an Option that sets a http.Client created by the factory.

--- a/provider.go
+++ b/provider.go
@@ -1,0 +1,6 @@
+package hfgo
+
+import "github.com/Kardbord/hfgo/v4/internal/providers"
+
+// Provider knows how to construct API endpoints for a given task and model.
+type Provider = providers.Provider

--- a/provider.go
+++ b/provider.go
@@ -4,3 +4,31 @@ import "github.com/Kardbord/hfgo/v4/internal/providers"
 
 // Provider knows how to construct API endpoints for a given task and model.
 type Provider = providers.Provider
+
+// Task identifies an inference task type.
+type Task = providers.Task
+
+const (
+	// TaskTextClassification is the text classification task.
+	TaskTextClassification = providers.TaskTextClassification
+	// TaskZeroShotTextClassification is the zero-shot text classification task.
+	TaskZeroShotTextClassification = providers.TaskZeroShotTextClassification
+	// TaskTokenClassification is the token classification task.
+	TaskTokenClassification = providers.TaskTokenClassification
+	// TaskQuestionAnswering is the question answering task.
+	TaskQuestionAnswering = providers.TaskQuestionAnswering
+	// TaskTableQuestionAnswering is the table question answering task.
+	TaskTableQuestionAnswering = providers.TaskTableQuestionAnswering
+	// TaskFillMask is the fill mask task.
+	TaskFillMask = providers.TaskFillMask
+	// TaskSummarization is the summarization task.
+	TaskSummarization = providers.TaskSummarization
+	// TaskTranslation is the translation task.
+	TaskTranslation = providers.TaskTranslation
+	// TaskFeatureExtraction is the feature extraction task.
+	TaskFeatureExtraction = providers.TaskFeatureExtraction
+	// TaskSentenceSimilarity is the sentence similarity task.
+	TaskSentenceSimilarity = providers.TaskSentenceSimilarity
+	// TaskChatCompletion is the chat completion task.
+	TaskChatCompletion = providers.TaskChatCompletion
+)

--- a/question_answering_service.go
+++ b/question_answering_service.go
@@ -36,14 +36,14 @@ func (s questionAnsweringService) answer(
 	if req.Parameters != nil && req.Parameters.TopK != nil && *req.Parameters.TopK > 1 {
 		return doModelInference[QuestionAnsweringRequest, []QuestionAnswering](
 			optsOverride,
-			"question answering",
+			TaskQuestionAnswering,
 			req,
 		)
 	}
 
 	single, err := doModelInference[QuestionAnsweringRequest, QuestionAnswering](
 		optsOverride,
-		"question answering",
+		TaskQuestionAnswering,
 		req,
 	)
 	if err != nil {

--- a/summarization_service.go
+++ b/summarization_service.go
@@ -21,7 +21,7 @@ func (s summarizationService) summarize(
 ) ([]Summarization, error) {
 	return doModelInference[SummarizationRequest, []Summarization](
 		s.opts.With(opts...),
-		"summarization",
+		TaskSummarization,
 		req,
 	)
 }
@@ -33,7 +33,7 @@ func (s summarizationService) summarizeBatch(
 ) ([]Summarization, error) {
 	return doModelInference[SummarizationBatchRequest, []Summarization](
 		s.opts.With(opts...),
-		"summarization",
+		TaskSummarization,
 		req,
 	)
 }

--- a/table_question_answering_service.go
+++ b/table_question_answering_service.go
@@ -26,7 +26,7 @@ func (s tableQuestionAnsweringService) answer(
 ) (TableQuestionAnswer, error) {
 	return doModelInference[TableQuestionAnsweringRequest, TableQuestionAnswer](
 		s.opts.With(opts...),
-		"table question answering",
+		TaskTableQuestionAnswering,
 		req,
 	)
 }

--- a/text_classification_service.go
+++ b/text_classification_service.go
@@ -27,7 +27,7 @@ func (s textClassificationService) classify(
 	// contains a list of TextClassification objects.
 	resp, err := doModelInference[TextClassificationRequest, [][]TextClassification](
 		optsOverride,
-		"text classification",
+		TaskTextClassification,
 		req,
 	)
 	if err != nil {
@@ -51,7 +51,7 @@ func (s textClassificationService) classifyBatch(
 
 	resp, err := doModelInference[TextClassificationBatchRequest, [][]TextClassification](
 		optsOverride,
-		"text classification",
+		TaskTextClassification,
 		req,
 	)
 	if err != nil {

--- a/token_classification_service.go
+++ b/token_classification_service.go
@@ -21,7 +21,7 @@ func (s tokenClassificationService) classify(
 ) ([]TokenClassification, error) {
 	return doModelInference[TokenClassificationRequest, []TokenClassification](
 		s.opts.With(opts...),
-		"token classification",
+		TaskTokenClassification,
 		req,
 	)
 }
@@ -33,7 +33,7 @@ func (s tokenClassificationService) classifyBatch(
 ) ([][]TokenClassification, error) {
 	return doModelInference[TokenClassificationBatchRequest, [][]TokenClassification](
 		s.opts.With(opts...),
-		"token classification",
+		TaskTokenClassification,
 		req,
 	)
 }

--- a/translation_service.go
+++ b/translation_service.go
@@ -21,7 +21,7 @@ func (s translationService) translate(
 ) ([]Translation, error) {
 	return doModelInference[TranslationRequest, []Translation](
 		s.opts.With(opts...),
-		"translation",
+		TaskTranslation,
 		req,
 	)
 }
@@ -33,7 +33,7 @@ func (s translationService) translateBatch(
 ) ([]Translation, error) {
 	return doModelInference[TranslationBatchRequest, []Translation](
 		s.opts.With(opts...),
-		"translation",
+		TaskTranslation,
 		req,
 	)
 }

--- a/zero_shot_text_classification_service.go
+++ b/zero_shot_text_classification_service.go
@@ -35,7 +35,7 @@ func (s zeroShotTextClassificationService) classify(
 
 	resp, err := doModelInference[ZeroShotTextClassificationRequest, []ZeroShotTextClassification](
 		optsOverride,
-		"zero-shot text classification",
+		TaskZeroShotTextClassification,
 		req,
 	)
 	if err != nil {
@@ -63,7 +63,7 @@ func (s zeroShotTextClassificationService) classifyBatch(
 
 	resp, err := doModelInference[ZeroShotTextClassificationBatchRequest, []zeroShotTextClassificationBatched](
 		optsOverride,
-		"zero-shot text classification",
+		TaskZeroShotTextClassification,
 		req,
 	)
 	if err != nil {


### PR DESCRIPTION
- Add Provider interface with Endpoint(task, model) and ProviderSuffix() methods
- Add HuggingFaceProvider implementation (ProviderSuffix returns "" for HF)
- Add Provider type alias at root level
- Change Options.Provider from string to Provider interface
- Add WithDefaultProvider() option mirroring WithDefaultHTTPClient()
- Default Provider to HuggingFaceProvider{} in NewOptions()
- Replace nil provider fallback with SDKError at point of use
- Rename Name() → ProviderSuffix() for clarity
- Update applyProvider to skip suffix when ProviderSuffix() returns ""
- Update all tests and documentation