### PR TITLE
fix: Add remaining inference task constants

### DIFF
--- a/internal/providers/huggingface.go
+++ b/internal/providers/huggingface.go
@@ -29,7 +29,7 @@ func (p HuggingFaceProvider) Endpoint(task Task, model string) (string, error) {
 		}
 	}
 
-	switch task {
+	switch task { //nolint:exhaustive // Additional hf-inference tasks are not yet supported by either the SDK or upstream API.
 	case TaskFeatureExtraction, TaskSentenceSimilarity:
 		return "hf-inference/models/" + model + "/pipeline/" + string(task), nil
 	case TaskChatCompletion:

--- a/internal/providers/task.go
+++ b/internal/providers/task.go
@@ -26,4 +26,38 @@ const (
 	TaskSentenceSimilarity Task = "sentence-similarity"
 	// TaskChatCompletion is the chat completion task.
 	TaskChatCompletion Task = "chat-completion"
+	// TaskTextToImage is the text to image task.
+	TaskTextToImage Task = "text-to-image"
+	// TaskTextGeneration is the text generation task.
+	TaskTextGeneration Task = "text-generation"
+	// TaskAudioClassification is the audio classification task.
+	TaskAudioClassification Task = "audio-classification"
+	// TaskAutomaticSpeechRecognition is the automatic speech recognition task.
+	TaskAutomaticSpeechRecognition Task = "automatic-speech-recognition"
+	// TaskImageClassification is the image classification task.
+	TaskImageClassification Task = "image-classification"
+	// TaskImageSegmentation is the image segmentation task.
+	TaskImageSegmentation Task = "image-segmentation"
+	// TaskDocumentQuestionAnswering is the document question answering task.
+	TaskDocumentQuestionAnswering Task = "document-question-answering"
+	// TaskImageToText is the image to text task.
+	TaskImageToText Task = "image-to-text"
+	// TaskObjectDetection is the object detection task.
+	TaskObjectDetection Task = "object-detection"
+	// TaskAudioToAudio is the audio to audio task.
+	TaskAudioToAudio Task = "audio-to-audio"
+	// TaskZeroShotImageClassification is the zero-shot image classification task.
+	TaskZeroShotImageClassification Task = "zero-shot-image-classification"
+	// TaskImageToImage is the image to image task.
+	TaskImageToImage Task = "image-to-image"
+	// TaskTabularClassification is the tabular classification task.
+	TaskTabularClassification Task = "tabular-classification"
+	// TaskTextToSpeech is the text to speech task.
+	TaskTextToSpeech Task = "text-to-speech"
+	// TaskVisualQuestionAnswering is the visual question answering task.
+	TaskVisualQuestionAnswering Task = "visual-question-answering"
+	// TaskTabularRegression is the tabular regression task.
+	TaskTabularRegression Task = "tabular-regression"
+	// TaskTextToAudio is the text to audio task.
+	TaskTextToAudio Task = "text-to-audio"
 )

--- a/provider.go
+++ b/provider.go
@@ -31,4 +31,38 @@ const (
 	TaskSentenceSimilarity = providers.TaskSentenceSimilarity
 	// TaskChatCompletion is the chat completion task.
 	TaskChatCompletion = providers.TaskChatCompletion
+	// TaskTextToImage is the text to image task.
+	TaskTextToImage = providers.TaskTextToImage
+	// TaskTextGeneration is the text generation task.
+	TaskTextGeneration = providers.TaskTextGeneration
+	// TaskAudioClassification is the audio classification task.
+	TaskAudioClassification = providers.TaskAudioClassification
+	// TaskAutomaticSpeechRecognition is the automatic speech recognition task.
+	TaskAutomaticSpeechRecognition = providers.TaskAutomaticSpeechRecognition
+	// TaskImageClassification is the image classification task.
+	TaskImageClassification = providers.TaskImageClassification
+	// TaskImageSegmentation is the image segmentation task.
+	TaskImageSegmentation = providers.TaskImageSegmentation
+	// TaskDocumentQuestionAnswering is the document question answering task.
+	TaskDocumentQuestionAnswering = providers.TaskDocumentQuestionAnswering
+	// TaskImageToText is the image to text task.
+	TaskImageToText = providers.TaskImageToText
+	// TaskObjectDetection is the object detection task.
+	TaskObjectDetection = providers.TaskObjectDetection
+	// TaskAudioToAudio is the audio to audio task.
+	TaskAudioToAudio = providers.TaskAudioToAudio
+	// TaskZeroShotImageClassification is the zero-shot image classification task.
+	TaskZeroShotImageClassification = providers.TaskZeroShotImageClassification
+	// TaskImageToImage is the image to image task.
+	TaskImageToImage = providers.TaskImageToImage
+	// TaskTabularClassification is the tabular classification task.
+	TaskTabularClassification = providers.TaskTabularClassification
+	// TaskTextToSpeech is the text to speech task.
+	TaskTextToSpeech = providers.TaskTextToSpeech
+	// TaskVisualQuestionAnswering is the visual question answering task.
+	TaskVisualQuestionAnswering = providers.TaskVisualQuestionAnswering
+	// TaskTabularRegression is the tabular regression task.
+	TaskTabularRegression = providers.TaskTabularRegression
+	// TaskTextToAudio is the text to audio task.
+	TaskTextToAudio = providers.TaskTextToAudio
 )


### PR DESCRIPTION
Add the remaining inference task constants. The `huggingface` provider's `Endpoint` method has not been updated to include them because they are not supported yet (either by the SDK, or by the upstream API in some cases).